### PR TITLE
fix(swipe): grant the pipeline access to the preview samples bucket (dev only)

### DIFF
--- a/terraform/swipe.tf
+++ b/terraform/swipe.tf
@@ -90,12 +90,36 @@ module "swipe" {
   #       czid-public-references -> seqtoid-public-references or wherever the public data lives
   #       idseq-workflows -> cypherid-samples-deleteme -> seqtoid-workflows or wherever the WDL files live
   #       idseq-database -> Is this supposed to be the same as idseq-workflows or seqtoid-public-references, or some other component?
+  # Per-PR preview sandboxes upload to their OWN bucket (seqtoid-preview-samples-<env>-<acct>,
+  # cypherid-web-infra), not idseq-samples-<env>. They were given a separate bucket so a sandbox can
+  # never write into `seqtoid-sandbox` -- which despite the name holds ~4.8 TB of the team's research
+  # data (validation sets, time trials, taxon indexes) and which the preview role could previously
+  # DELETE from.
+  #
+  # But THIS pipeline was never told that bucket exists, so a sandbox's Step Functions execution died
+  # 1.4s in at the first state:
+  #   PreprocessInput -> AccessDenied: idseq-swipe-dev-preprocess_input is not authorized to perform
+  #   s3:PutObject on seqtoid-preview-samples-dev-.../samples/1/1/1/short-read-mngs-8/host_filter_input.json
+  # The sandbox could dispatch, but the pipeline could not read its inputs or write its outputs --
+  # leaving the sandbox usable for UI review only, never for running a sample.
+  #
+  # This list is the ONLY feed for those grants: swipe expands it into the sfn-io-helper lambda role
+  # policies (one shared document, for_each over 8 lambdas) and the batch-job policy. Same actions,
+  # same bucket-wide scope idseq-samples-<env> already has -- not a broader grant, just the same one
+  # for the bucket sandboxes actually use.
+  #
+  # DEV ONLY, deliberately. The lookup's default arm is shared by dev, staging, sandbox AND test
+  # (only prod has its own), so appending unconditionally would grant this in staging and sandbox
+  # too. Preview sandboxes exist only on dev; the bucket does not exist elsewhere.
   workspace_s3_prefixes = lookup(
     {
       "prod" : ["idseq-prod-samples-us-west-2", "czid-public-references", local.s3_bucket_public_references, local.s3_bucket_workflows, "idseq-prod-system-test"],
     },
     var.DEPLOYMENT_ENVIRONMENT,
-    ["idseq-samples-${var.DEPLOYMENT_ENVIRONMENT}-${var.AWS_ACCOUNT_ID}", "czid-public-references", local.s3_bucket_public_references, local.s3_bucket_workflows]
+    concat(
+      ["idseq-samples-${var.DEPLOYMENT_ENVIRONMENT}-${var.AWS_ACCOUNT_ID}", "czid-public-references", local.s3_bucket_public_references, local.s3_bucket_workflows],
+      var.DEPLOYMENT_ENVIRONMENT == "dev" ? ["seqtoid-preview-samples-dev-${var.AWS_ACCOUNT_ID}"] : []
+    )
   )
 
   extra_env_vars = {


### PR DESCRIPTION
Replaces #7, which I branched off a **stale local `main`** -- it carried 17 unrelated commits (already upstream via the itars-sync merges) and conflicted. This is the same one-line fix, branched cleanly off `itars/main`: **1 file, +25/-1**.

## The failure
A per-PR sandbox now dispatches a **real Step Functions execution**, which dies **1.4s in at the first state**:

```
TaskStateEntered: PreprocessInput
TaskFailed: ClientError
  AccessDenied calling PutObject:
  idseq-swipe-dev-preprocess_input is not authorized on
  "arn:aws:s3:::seqtoid-preview-samples-dev-491013321714/samples/1/1/1/short-read-mngs-8/host_filter_input.json"
```

Sandboxes were given their **own** samples bucket so one can never write into `seqtoid-sandbox` -- which despite the name holds **~4.8 TB of research data**, and which the preview role could previously **DELETE** from. That isolation is correct and stays. But **this pipeline was never told the new bucket exists**, so a sandbox could dispatch and then never process a sample -- useful for **UI review only**.

## Scope: one list entry
`workspace_s3_prefixes` is the **only** feed for these grants. swipe (pinned `v1.4.9`) expands it into the sfn-io-helper lambda role policies (one shared doc, `for_each` over 8 lambdas) and the batch-job policy.

**Verified before changing anything:**
- The failing role comes from the **remote swipe module**, not this repo's templates. Editing `iam_policy_templates/batch_job.json` or `lambdas/sfn-io-helper/policy-template.json` would **not** have fixed it -- the state machine invokes *swipe's* sfn-io-helper.
- **No `/samples/*` scoping to mirror** -- grants are already bucket-wide. This is **exactly** the scope `idseq-samples-<env>` has, not broader.
- Batch **instance** role and SFN service role have **no S3 grants** -- untouched.
- **No SFN template hardcodes a bucket** -- paths arrive in the execution input.
- `terraform/variables.tf` is **generated** by the `environment` script -- the change belongs in `swipe.tf`.

## Dev only, deliberately
The lookup's **default arm is shared by dev, staging, sandbox AND test** (only `prod` has its own). An unconditional append would have granted this in staging and sandbox too.

## Blast radius
These roles run **dev's real pipelines**. Expect **~9 in-place IAM policy updates** and nothing else. **Any role/lambda/SFN replacement is a red flag -- stop the apply.** Regression check after: dev's own pipelines must still run.

**Acceptance:** a sandbox sample runs short-read-mngs to SUCCEEDED end to end.