### PR TITLE
ci(plan): assume the plan role, not the retired executor

### DIFF
--- a/.github/workflows/plan_call.yml
+++ b/.github/workflows/plan_call.yml
@@ -46,7 +46,17 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6.1.0
         if: ${{ !env.ACT }}
         with:
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment }}-gh-actions-executor
+          # The read-only plan role, NOT the legacy `-gh-actions-executor`. The executor was
+          # retained only until workflows cut over to the split plan/apply roles; the apply paths
+          # here (deploy.yml, publish-workflows.yml) were cut over and this one was missed, so it
+          # still assumed a role that has no policy attachments at all. The first thing that failed
+          # was the account-alias guard in `environment`: PowerUserAccess/executor cannot call
+          # iam:ListAccountAliases, the guard read an empty alias, refused to continue, and unset
+          # TF_DATA_DIR -- surfacing as `mkdir: cannot create directory ''`, which names neither the
+          # role nor the denial. The plan role carries ReadOnlyAccess (which does allow
+          # ListAccountAliases) plus scoped tfstate read, and its subject_ref_pattern is `*`, so the
+          # `environment:<env>` OIDC subject this job presents is accepted.
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment }}-gh-actions-plan
           output-env-credentials: true
           #role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/plan_only.yml
+++ b/.github/workflows/plan_only.yml
@@ -2,7 +2,7 @@ name: Plan only
 run-name: Plan only in env ${{ inputs.environment || github.base_ref || github.ref_name }} branch ${{ github.base_ref || github.ref_name }} by ${{ github.actor }}
 
 on:
-  # Planning assumes an AWS OIDC role (czid-<env>-gh-actions-executor) and reads
+  # Planning assumes an AWS OIDC role (czid-<env>-gh-actions-plan) and reads
   # the real S3 backend, so it can't run until GitHub Environments + OIDC roles
   # exist (CZID-81 / CZID-26). Until then it is manual-only; the no-AWS
   # validate.yml is the automatic push/PR gate.


### PR DESCRIPTION
## What

The plan job assumed `czid-<env>-gh-actions-executor` -- a legacy role that `cypherid-web-infra` retained *only* until workflows cut over to the split plan/apply roles, and which has **no policy attachments at all**. The apply paths in this repo (`deploy.yml`, `publish-workflows.yml`) were already cut over to `-gh-actions-apply`; `plan_call.yml` was missed.

## Why the error didn't say so

The failure named neither the role nor the permission:

```
mkdir: cannot create directory '': No such file or directory
```

The real sequence, from the `set -x` trace:

1. `environment` runs an account-alias guard: `aws iam list-account-aliases`
2. `PowerUserAccess` excludes `iam:*` (its `NotAction` is `["iam:*", "organizations:*", "account:*"]`), so this is **AccessDenied** -- the alias reads back empty
3. The guard compares `'' != seqtoid-dev`, prints "Expected to be in AWS account seqtoid-dev, but got ", and `return`s
4. On the way out it `unset`s `TF_DATA_DIR`, so the next `mkdir "$TF_DATA_DIR"` gets an empty string

The role assumed fine and `sts:GetCallerIdentity` worked -- only the IAM read was denied.

## Why the plan role fits

- `ReadOnlyAccess` **does** allow `iam:ListAccountAliases`, so the guard passes
- Its scoped tfstate-read grant covers this repo's dev backend (`tfstate-<acct>-test`)
- `subject_ref_pattern = "*"` accepts the `environment:<env>` OIDC subject this job presents
- The cztack module still denies `:pull_request` subjects, so the read-only-plan boundary is unchanged

This is the exact follow-up prescribed in `cypherid-web-infra`'s `github-actions-runner-permissions.tf`.

## Scope

Workflow-only. No Terraform, no IAM change, no infrastructure touched. Also corrects a stale comment in `plan_only.yml` naming the same retired role.

## Known remaining unknown

The guard also requires the account alias to literally equal `seqtoid-dev`. If the alias is unset or still carries a `czid-*` name, this will fail again -- but with a truthful message instead of a misleading `mkdir` error. The guard runs before Terraform and fails closed, so no infrastructure is at risk either way.