### PR TITLE
ci(plan): forward the sourced environment to later steps

### DIFF
--- a/.github/workflows/plan_call.yml
+++ b/.github/workflows/plan_call.yml
@@ -90,6 +90,23 @@ jobs:
           mkdir -p "$TF_DATA_DIR"
           jq -n ".region=\"us-west-2\" | .bucket=env.TF_S3_BUCKET | .key=env.APP_NAME+env.DEPLOYMENT_ENVIRONMENT | .encrypt=true" > "$TF_DATA_DIR/aws_config.json"
           jq . "$TF_DATA_DIR/aws_config.json"
+
+          # Hand the sourced environment to the LATER steps. Every `run:` block is its own shell,
+          # so nothing `environment.<env>` exports survives past this step -- which made this step a
+          # no-op for everything downstream and meant this workflow could never have completed a
+          # plan. `make` tripped its own DEPLOYMENT_ENVIRONMENT guard first ("Please run source
+          # environment..."), and had it not, `terraform init` would have failed next with no
+          # TF_CLI_ARGS_init to point it at the S3 backend.
+          #
+          # Only the variables `environment` derives are forwarded. AWS credentials are NOT included:
+          # configure-aws-credentials already publishes those, and $GITHUB_ENV is plain text in the
+          # runner log.
+          for v in APP_HOME APP_NAME DEPLOYMENT_ENVIRONMENT TF_DATA_DIR TFSTATE_FILE \
+                   TF_CLI_ARGS_init TF_CLI_ARGS_output AWS_SDK_LOAD_CONFIG AWS_DEFAULT_REGION \
+                   AWS_ACCOUNT_ID AWS_ACCOUNT_ALIAS TF_S3_BUCKET DOCKER_REGISTRY \
+                   OWNER TF_VAR_owner TF_VAR_environment; do
+            printf '%s=%s\n' "$v" "${!v}" >> "$GITHUB_ENV"
+          done
       - name: Package Lambdas and create Templates
         run: |
           make package-lambdas templates


### PR DESCRIPTION
## What

`Setup Terraform Environment` sourced `environment.<env>` and then discarded everything it set. Each `run:` block is its own shell, so `DEPLOYMENT_ENVIRONMENT`, `TF_DATA_DIR`, `TF_S3_BUCKET` and `TF_CLI_ARGS_init` never reached the steps that consume them. That step was a **no-op for every step after it**, and this workflow could not have completed a plan in its current form.

## Evidence

With the role fix in place, the run got past AWS auth and died here:

```
Run make package-lambdas templates
Makefile:7: *** Please run "source environment" in the repo root directory before running make commands.  Stop.
```

`make` tripped its own `ifndef DEPLOYMENT_ENVIRONMENT` guard. Had that passed, `terraform init` would have failed next with no `TF_CLI_ARGS_init` to point it at the S3 backend.

## Fix

Forward the variables `environment` derives through `$GITHUB_ENV`.

AWS credentials are deliberately **not** forwarded -- `configure-aws-credentials` already publishes them into the job env, and `$GITHUB_ENV` is plain text.

The generated `terraform/variables.tf` needs nothing here: it is a file on disk and already survived the step boundary.

## Scope

Workflow-only. No Terraform, no IAM, no infrastructure touched.

## Note

This is the second wall in front of this repo's plan gate; the first was the plan job assuming the retired executor role. The apply path (`deploy.yml`) does **not** have this bug -- it sources and runs `make` inside a single step, which is why it was never exposed.