### PR TITLE
ci(plan): drop the state lock, restore refresh

### DIFF
--- a/.github/workflows/plan_call.yml
+++ b/.github/workflows/plan_call.yml
@@ -118,7 +118,25 @@ jobs:
           terraform init -input=false
           echo "Plan will be created in: ${{ github.workspace }}/tf.plan"
           set +e
-          terraform plan -input=false -detailed-exitcode -refresh=false -out="${{ github.workspace }}/tf.plan"
+          # -lock=false: this backend uses S3-native lockfile locking (use_lockfile = true), so
+          # acquiring a lock means PutObject on <bucket>/idseqdev.tflock. The plan role is
+          # read-only by design and cannot write it:
+          #
+          #   Error acquiring the state lock ... czid-dev-gh-actions-plan is not authorized to
+          #   perform: s3:PutObject on "tfstate-491013321714-test/idseqdev.tflock"
+          #
+          # A plan writes no state, so it needs no lock. The apply path keeps locking -- it runs as
+          # the apply role, which holds tfstate read/write.
+          #
+          # Refresh is deliberately ON. With -refresh=false terraform compares config against the
+          # STATE FILE rather than against AWS, so the diff omits anything that drifted out of band
+          # and a clean plan proves nothing about the real account. The apply this plan gates
+          # (`make deploy` -> `terraform apply`) DOES refresh, so a -refresh=false plan can and does
+          # understate what the apply will do -- the plan stops being a review of the apply.
+          # Refreshing only reads AWS (covered by the plan role's ReadOnlyAccess) and is held in
+          # memory; `terraform plan` never persists refreshed state, which is also why dropping the
+          # lock above stays safe.
+          terraform plan -input=false -detailed-exitcode -lock=false -out="${{ github.workspace }}/tf.plan"
           exitcode=$?
           echo "Terraform exited with exit-code $exitcode"
           if [[ $exitcode -eq 1 ]]; then

--- a/.github/workflows/plan_call.yml
+++ b/.github/workflows/plan_call.yml
@@ -90,6 +90,23 @@ jobs:
           mkdir -p "$TF_DATA_DIR"
           jq -n ".region=\"us-west-2\" | .bucket=env.TF_S3_BUCKET | .key=env.APP_NAME+env.DEPLOYMENT_ENVIRONMENT | .encrypt=true" > "$TF_DATA_DIR/aws_config.json"
           jq . "$TF_DATA_DIR/aws_config.json"
+
+          # Hand the sourced environment to the LATER steps. Every `run:` block is its own shell,
+          # so nothing `environment.<env>` exports survives past this step -- which made this step a
+          # no-op for everything downstream and meant this workflow could never have completed a
+          # plan. `make` tripped its own DEPLOYMENT_ENVIRONMENT guard first ("Please run source
+          # environment..."), and had it not, `terraform init` would have failed next with no
+          # TF_CLI_ARGS_init to point it at the S3 backend.
+          #
+          # Only the variables `environment` derives are forwarded. AWS credentials are NOT included:
+          # configure-aws-credentials already publishes those, and $GITHUB_ENV is plain text in the
+          # runner log.
+          for v in APP_HOME APP_NAME DEPLOYMENT_ENVIRONMENT TF_DATA_DIR TFSTATE_FILE \
+                   TF_CLI_ARGS_init TF_CLI_ARGS_output AWS_SDK_LOAD_CONFIG AWS_DEFAULT_REGION \
+                   AWS_ACCOUNT_ID AWS_ACCOUNT_ALIAS TF_S3_BUCKET DOCKER_REGISTRY \
+                   OWNER TF_VAR_owner TF_VAR_environment; do
+            printf '%s=%s\n' "$v" "${!v}" >> "$GITHUB_ENV"
+          done
       - name: Package Lambdas and create Templates
         run: |
           make package-lambdas templates


### PR DESCRIPTION
## What

Two fixes to the `terraform plan` invocation. `terraform init` now succeeds and the backend configures cleanly; this is the last wall in front of a working plan.

### 1. `-lock=false`

This backend uses S3-native lockfile locking (`use_lockfile = true`), so acquiring a lock means `PutObject` on `<bucket>/idseqdev.tflock`. The plan role is read-only **by design** and cannot write it:

```
Error acquiring the state lock
... czid-dev-gh-actions-plan is not authorized to perform: s3:PutObject
on resource: "arn:aws:s3:::tfstate-491013321714-test/idseqdev.tflock"
```

The role is not wrong -- asking a read-only plan to take a write lock is. A plan writes no state and needs no lock.

The **apply path keeps locking**: it runs as the apply role, which holds tfstate read/write. Concurrent-apply protection is unchanged.

### 2. Refresh restored

`-refresh=false` compares config against the **state file**, not against AWS. Drift that happened out of band is silently absent from the diff, so a clean plan proves nothing about the real account.

That matters specifically here: the apply this plan gates (`make deploy` -> `terraform apply`) **does** refresh. A `-refresh=false` plan can therefore understate what the apply will actually do -- which defeats the entire purpose of reviewing a plan before applying.

Refreshing only **reads** AWS (covered by the plan role's `ReadOnlyAccess`) and is held in memory; `terraform plan` never persists refreshed state. That is also what keeps `-lock=false` safe.

## Scope

Workflow-only. No Terraform, no IAM, no infrastructure touched.