### PR TITLE
feat(ci): allow scoping a plan/apply to specific targets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,17 @@ on:
         required: true
         type: string
         default: 'dev'
+      targets:
+        description: >-
+          Optional space-separated terraform resource addresses. When set, the apply is limited to
+          these (-target) instead of the whole configuration. This apply is --auto-approve with no
+          plan-linkage, so it applies whatever the config wants at run time; scoping it is how a
+          narrow change gets applied without dragging along unrelated pending drift. Plan the same
+          targets with the "Plan only" workflow first and confirm the diff. Leave empty for a full
+          apply.
+        required: false
+        type: string
+        default: ''
 
 env:
   AWS_REGION : us-west-2
@@ -57,4 +68,17 @@ jobs:
           #trap 'scripts/report_deployment_status.sh failure' ERR
           #scripts/report_deployment_status.sh in_progress "Starting deployment"
           source scripts/init_ci_runner.sh
+
+          # Optional -target scoping. init_ci_runner.sh sets TF_CLI_ARGS_apply=--auto-approve, so
+          # append rather than assign, and do it after sourcing or it gets overwritten.
+          if [[ -n "${{ inputs.targets }}" ]]; then
+            for t in ${{ inputs.targets }}; do
+              TF_CLI_ARGS_apply="$TF_CLI_ARGS_apply -target=$t"
+            done
+            export TF_CLI_ARGS_apply
+            echo "SCOPED APPLY -- terraform will touch only the targets below, not the full config:"
+            printf '  %s\n' ${{ inputs.targets }}
+          fi
+          echo "TF_CLI_ARGS_apply=$TF_CLI_ARGS_apply"
+
           make deploy

--- a/.github/workflows/plan_call.yml
+++ b/.github/workflows/plan_call.yml
@@ -7,6 +7,14 @@ on:
         description: Both Github Environment and AWS Environment
         type: string
         required: true
+      targets:
+        description: >-
+          Optional space-separated terraform resource addresses. When set, the plan is limited to
+          these (-target) instead of the whole configuration. Use to review a narrow change against
+          a state that carries unrelated pending drift; leave empty for the full plan.
+        type: string
+        required: false
+        default: ''
     outputs:
       plan-artifact-id:
         description: The Artifact ID of the generated Terraform Plan
@@ -136,7 +144,17 @@ jobs:
           # Refreshing only reads AWS (covered by the plan role's ReadOnlyAccess) and is held in
           # memory; `terraform plan` never persists refreshed state, which is also why dropping the
           # lock above stays safe.
-          terraform plan -input=false -detailed-exitcode -lock=false -out="${{ github.workspace }}/tf.plan"
+          # Optional -target scoping. Empty (the default) plans the whole configuration.
+          targets=()
+          for t in ${{ inputs.targets }}; do
+            targets+=("-target=$t")
+          done
+          if [[ ${#targets[@]} -gt 0 ]]; then
+            echo "NOTE: plan is scoped to ${#targets[@]} target(s); it does NOT show the full diff."
+            printf '  %s\n' "${targets[@]}"
+          fi
+
+          terraform plan -input=false -detailed-exitcode -lock=false "${targets[@]}" -out="${{ github.workspace }}/tf.plan"
           exitcode=$?
           echo "Terraform exited with exit-code $exitcode"
           if [[ $exitcode -eq 1 ]]; then

--- a/.github/workflows/plan_only.yml
+++ b/.github/workflows/plan_only.yml
@@ -13,6 +13,13 @@ on:
         required: true
         type: environment
         default: dev
+      targets:
+        description: >-
+          Optional space-separated terraform addresses to limit the plan to (-target). Leave empty
+          for the full plan.
+        required: false
+        type: string
+        default: ''
 
 env:
   branch_name: ${{ github.base_ref || github.ref_name }}
@@ -67,6 +74,7 @@ jobs:
     uses: ./.github/workflows/plan_call.yml
     with:
       environment: ${{ needs.should-plan.outputs.environment }}
+      targets: ${{ inputs.targets }}
     secrets: inherit
 
   plan-summary:


### PR DESCRIPTION
## Why

The Deploy workflow has **never run in this org** -- zero runs, ever. State therefore carries a large backlog of pending drift. The first working full plan against dev is **103 changes**:

| Action | Count |
| ------ | ----- |
| create | 53 |
| update | 44 |
| delete | 6 |

Including 9 new Batch compute environments + 7 job-queue updates (a compute-environment swap on the live dev pipelines), a KMS key, a new S3 bucket, 9 VPC endpoints, 14 CloudWatch alarms, and deletion of the `nextgen-web` SQS queues + DLQ + SNS subscription (`nextgen` appears in 0 config files, so Terraform reads them as intentionally removed).

`make deploy` is `terraform apply --auto-approve` with no plan-linkage. So applying a one-line IAM change today means auto-approving all 103.

## What

An optional space-separated `targets` input on the plan and deploy workflows, mapped to `-target`.

**Empty (the default) changes nothing**: full plan, full apply, exactly as before.

## Notes

- On the apply side the append happens **after** `source scripts/init_ci_runner.sh`, which assigns `TF_CLI_ARGS_apply=--auto-approve` unconditionally and would otherwise clobber it.
- Both paths echo the scope they are running under. A `-target`'d run silently ignores the rest of the config, and that deserves to be said out loud in the log rather than inferred.
- Plan the targets first and confirm the diff before the scoped apply -- the apply auto-approves and has no plan-linkage, so the plan is the only review.

## This is a workaround, not a fix

Scoping lets a reviewed change land without dragging along 94 unrelated ones. **The backlog still needs a reviewed full apply** -- tracked separately.