### PR TITLE
fix(deploy): set aws-profile so the region survives

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,18 @@ jobs:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment }}-gh-actions-apply
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
+          # aws-profile is load-bearing, not tidiness. `environment` derives the region with
+          #   AWS_DEFAULT_REGION=$(aws configure get region)
+          # which reads the profile CONFIG FILE, not the aws-region input above and not the
+          # AWS_DEFAULT_REGION that init_ci_runner.sh already exported. Without a profile written to
+          # disk that command returns empty and the assignment silently overwrites a correct region
+          # with nothing:
+          #   +++++ aws configure get region
+          #   ++++ AWS_DEFAULT_REGION=
+          # Every later AWS call then runs with no region. plan_call.yml sets aws-profile, which is
+          # why the plan path works and this one did not.
+          aws-profile: idseq-${{ inputs.environment }}
+          output-env-credentials: true
       - name: Sts GetCallerIdentity
         run: |
           aws sts get-caller-identity


### PR DESCRIPTION
## What

The deploy job never reached terraform. `environment` derives the region with:

```bash
AWS_DEFAULT_REGION=$(aws configure get region)
```

That reads the **profile config file on disk** -- not the action's `aws-region` input, and not the `AWS_DEFAULT_REGION` that `init_ci_runner.sh` already exported. `deploy.yml` passed no `aws-profile`, so no profile config existed, the command returned empty, and the assignment overwrote a correct region with nothing:

```
+++++ aws configure get region
++++ AWS_DEFAULT_REGION=
```

Every AWS call after that ran with no region.

## Fix

`plan_call.yml` already sets `aws-profile` -- which is precisely why the plan path works and this one did not. Mirror it here, plus `output-env-credentials` so terraform keeps seeing credentials in the environment exactly as it does on the plan path.

## Note

The deeper wart is that `environment` clobbers an explicitly-set `AWS_DEFAULT_REGION` rather than honouring it. Deliberately not touched here: that script is shared with local developer shells, and this change keeps CI consistent with the path already proven to work.

## Scope

Workflow-only. No Terraform, no IAM, no infrastructure touched.