### PR TITLE
feat(taxon-indexing): per-invocation es_host to isolate sandbox indexing

### DIFF
--- a/lambdas/taxon-indexing-concurrency-manager/app.js
+++ b/lambdas/taxon-indexing-concurrency-manager/app.js
@@ -16,7 +16,7 @@ let {
 CONCURRENCY = parseInt(CONCURRENCY) || 50
 const DEFAULT_ES_BATCHSIZE = 1000
 
-async function invoke_taxon_indexing(pipeline_run_ids, background_id, concurrency, es_batchsize) {
+async function invoke_taxon_indexing(pipeline_run_ids, background_id, concurrency, es_batchsize, es_host) {
     const limit = pLimit(concurrency);
 
     const result = await Promise.all(
@@ -27,7 +27,11 @@ async function invoke_taxon_indexing(pipeline_run_ids, background_id, concurrenc
                         pipeline_run_id,
                         background_id,
                         es_batchsize,
-                        concurrency
+                        concurrency,
+                        // Forward the caller's target OpenSearch host to each worker so a preview
+                        // sandbox's indexing lands in its isolated sandbox domain. Undefined for
+                        // dev/staging/prod -> JSON.stringify drops it -> worker uses its own host.
+                        es_host
                     }).catch(
                         (error) => {
                             if (!(error instanceof TooManyRequestsException)) {
@@ -77,6 +81,7 @@ export const handler = async (event, context) => {
     const background_id = event.background_id
     const concurrency = event.concurrency || CONCURRENCY
     const es_batchsize = event.es_batchsize || DEFAULT_ES_BATCHSIZE
+    const es_host = event.es_host
 
-    return invoke_taxon_indexing(pipeline_run_ids, background_id, concurrency, es_batchsize)
+    return invoke_taxon_indexing(pipeline_run_ids, background_id, concurrency, es_batchsize, es_host)
   }

--- a/lambdas/taxon-indexing/app.py
+++ b/lambdas/taxon-indexing/app.py
@@ -47,7 +47,16 @@ def index_taxons(event, context):
     )
     pipeline_runs_index_name = event.get("pipeline_runs_index_name", "pipeline_runs")
 
-    create_pipeline_run(pipeline_run_id, background_id, pipeline_runs_index_name)
+    # Per-invocation OpenSearch target. Preview sandboxes pass their own HEATMAP_ES_ADDRESS
+    # (= the isolated sandbox domain) as es_host so a sandbox pipeline run's taxon indexing lands
+    # in the sandbox domain, never dev's. dev/staging/prod omit es_host and use the module-level
+    # `es` client built from the DEPLOYMENT_ENVIRONMENT-configured host (unchanged behavior).
+    es_host = event.get("es_host")
+    es_client = OpenSearch(es_host, timeout=120) if es_host else es
+
+    create_pipeline_run(
+        pipeline_run_id, background_id, pipeline_runs_index_name, es_client
+    )
     if "LOCAL_MODE" in os.environ:
         # in local mode, passing a password parameter (even None)
         # will cause the connection to fail
@@ -88,18 +97,20 @@ def index_taxons(event, context):
             scored_taxon_counts_index_name,
             batchsize=es_batchsize,
         ):
-            bulk_index_taxon_metrics(batch)
+            bulk_index_taxon_metrics(batch, es_client)
 
     # refresh the index so that all written records are available to search before returning
     try:
-        response = es.indices.refresh(index=scored_taxon_counts_index_name)
+        response = es_client.indices.refresh(index=scored_taxon_counts_index_name)
     except Exception as exc:
         # The heatmap ES timeout used to die silently in CloudWatch; make it
         # visible in Sentry, then re-raise so the Lambda still fails.
         capture_exception(exc)
         raise
     logger.info(response)
-    complete_pipeline_run(pipeline_run_id, background_id, pipeline_runs_index_name)
+    complete_pipeline_run(
+        pipeline_run_id, background_id, pipeline_runs_index_name, es_client
+    )
 
     conn.close()
 
@@ -217,12 +228,13 @@ def index_taxon_metrics(taxon_metrics, index_name):
     logger.info(response)
 
 
-def bulk_index_taxon_metrics(batch):
+def bulk_index_taxon_metrics(batch, es_client=None):
     """
     Write a batch of taxons to ES
     """
+    es_client = es_client or es
     if batch:
-        response = es.bulk(batch)
+        response = es_client.bulk(batch)
         if response["errors"]:
             errors = [
                 item["index"]["error"]
@@ -243,13 +255,14 @@ def bulk_index_taxon_metrics(batch):
         logger.info(response)
 
 
-def create_pipeline_run(pipeline_run_id, background_id, index_name):
+def create_pipeline_run(pipeline_run_id, background_id, index_name, es_client=None):
     """
     Create/overwrite the pipeline_runs index record
     for the given pipeline so that we can track the
     completeness of the scored_taxon_counts writes
     """
-    response = es.index(
+    es_client = es_client or es
+    response = es_client.index(
         index=index_name,
         body={
             "pipeline_run_id": pipeline_run_id,
@@ -263,13 +276,14 @@ def create_pipeline_run(pipeline_run_id, background_id, index_name):
     logger.info(response)
 
 
-def complete_pipeline_run(pipeline_run_id, background_id, index_name):
+def complete_pipeline_run(pipeline_run_id, background_id, index_name, es_client=None):
     """
     Update the pipeline_run index record to indicate
     that all scored_taxon_count records were
     successfully written
     """
-    response = es.update(
+    es_client = es_client or es
+    response = es_client.update(
         index=index_name,
         body={"doc": {"is_complete": True}},
         id=f"{pipeline_run_id}_{background_id}",

--- a/lambdas/taxon-indexing/chalicelib/schemas.py
+++ b/lambdas/taxon-indexing/chalicelib/schemas.py
@@ -32,5 +32,16 @@ INPUT = {
             "type": "string",
             "title": "The index to use for pipeline runs",
         },
+        "es_host": {
+            "$id": "#/properties/es_host",
+            "type": "string",
+            "title": "Override OpenSearch host to index into",
+            "description": (
+                "Target OpenSearch endpoint for this invocation. When set (e.g. a preview "
+                "sandbox passing its own HEATMAP_ES_ADDRESS = the sandbox domain), the Lambda "
+                "writes into that domain instead of its own DEPLOYMENT_ENVIRONMENT-configured "
+                "host. Omitted for dev/staging/prod, which fall back to the configured host."
+            ),
+        },
     },
 }


### PR DESCRIPTION
## What
The taxon-indexing worker + concurrency-manager now accept an optional `es_host` in the invocation event and index into THAT OpenSearch domain, falling back to the DEPLOYMENT_ENVIRONMENT-configured host when absent.

## Why
Step 2 of the sandbox taxon/OpenSearch isolation (domain shipped in web-infra #41 -> `czid-sandbox-heatmap-es`). The Rails app will pass each pod's own `HEATMAP_ES_ADDRESS` as `es_host`, so a preview sandbox's taxon indexing lands in the sandbox domain, never dev's `czid-dev-heatmap-es`. Chosen over a separate sandbox-stage lambda fleet (which would need a new deploy env + IAM apply role) — same isolation, far less infra.

## Changes
- **worker** (`lambdas/taxon-indexing/app.py`): per-invocation OpenSearch client from `event['es_host']`, threaded through create/bulk/complete/refresh. Helpers default `es_client=None` -> module client, so **dev/staging/prod behavior is byte-identical** when `es_host` is absent.
- **concurrency-manager** (`app.js`): forwards `event.es_host` to each worker payload (undefined drops out of JSON).
- **schemas.py**: documents `es_host` (optional).

## Safety
Backward-compatible no-op until a caller passes `es_host` — safe to deploy ahead of the app change. Eviction untouched: its scheduled run is already per-env (dev eviction only touches dev's domain), so it's inherently isolated.

Pairs with a seqtoid-web change that adds `es_host: ENV['HEATMAP_ES_ADDRESS']` to the lambda payloads + sandbox.rake pointing sandboxes at the sandbox domain.