### PR TITLE
fix(concurrency-manager): drop managed log group to unblock es_host deploy

### DIFF
--- a/terraform/idseq.tf
+++ b/terraform/idseq.tf
@@ -26,9 +26,8 @@ module "taxon-indexing-concurrency-manager" {
   deployment_environment  = var.DEPLOYMENT_ENVIRONMENT
   index_taxon_lambda_arn  = module.taxon-indexing.lambda_arn
   index_taxon_lambda_name = module.taxon-indexing.lambda_name
-  # CZID-63: bound log retention + encrypt the lambda log group with the workflows CMK.
-  log_retention_in_days = var.lambda_log_retention_in_days
-  log_kms_key_arn       = aws_kms_key.workflows.arn
+  # CZID-63 log-group inputs (log_retention_in_days / log_kms_key_arn) removed with the managed log
+  # group resource -- see the follow-up note in the module's main.tf. Restore when re-adopted.
 }
 
 module "taxon-indexing-eviction" {

--- a/terraform/modules/taxon-indexing-concurrency-manager/main.tf
+++ b/terraform/modules/taxon-indexing-concurrency-manager/main.tf
@@ -57,28 +57,16 @@ resource "aws_iam_role_policy" "taxon_indexing_concurrency_manager_role" {
   })
 }
 
-# CloudWatch log group for the concurrency-manager lambda (CZID-63). Declared explicitly
-# for bounded retention + encryption-at-rest instead of the implicit, never-expiring group
-# Lambda auto-creates. Created before the function (depends_on) so it writes into this group.
-# In an env where the implicit group already exists, import it once before the first apply.
-#
-# TEMPORARY (dev state adoption): dev's group was auto-created by Lambda (no retention, no KMS)
-# before this resource existed, so a plain apply hits ResourceAlreadyExistsException. This import
-# block adopts the existing group into state so the apply RECONCILES it (adds retention + the
-# workflows CMK) instead of trying to create it. Remove this block immediately after the dev apply
-# runs once. Only dev has this lambda deployed today; do NOT deploy the concurrency-manager to
-# staging/prod while this block is present -- the per-env id would not resolve there.
-import {
-  to = aws_cloudwatch_log_group.taxon_indexing_concurrency_manager
-  id = "/aws/lambda/taxon-indexing-concurrency-manager-${var.deployment_environment}"
-}
-
-resource "aws_cloudwatch_log_group" "taxon_indexing_concurrency_manager" {
-  #checkov:skip=CKV_AWS_338:90-day retention (var.log_retention_in_days) is the deliberate cost/policy choice for this lambda log group; CKV_AWS_338 wants >=1 year. Logs are KMS-encrypted via the workflows CMK (var.log_kms_key_arn).
-  name              = "/aws/lambda/taxon-indexing-concurrency-manager-${var.deployment_environment}"
-  retention_in_days = var.log_retention_in_days
-  kms_key_id        = var.log_kms_key_arn
-}
+# NOTE (CZID-63 follow-up): a managed CloudWatch log group for this lambda was reverted. It was
+# declared for bounded retention + CMK encryption, but in dev Lambda had already auto-created the
+# implicit `/aws/lambda/taxon-indexing-concurrency-manager-dev` group (no retention, no KMS), so
+# every apply failed with ResourceAlreadyExistsException -- which blocked deploying this lambda at
+# all. Adopting the existing group needs `terraform import`, and a declarative `import` block only
+# takes effect in a FULL plan; this repo deploys with `-target` (which skips import blocks), and a
+# full dev apply is unsafe (a large, destroy-carrying backlog). So the managed group is removed here
+# to unblock lambda deploys. The lambda still logs to the implicit auto-created group. Re-adopt the
+# group with retention + the workflows CMK once the dev backlog is reconciled (via a full apply that
+# processes an import block, or a one-off `terraform import`). Tracked as a follow-up.
 
 resource "aws_lambda_function" "taxon_indexing_concurrency_manager" {
   function_name    = "taxon-indexing-concurrency-manager-${var.deployment_environment}"
@@ -94,7 +82,4 @@ resource "aws_lambda_function" "taxon_indexing_concurrency_manager" {
     }
   }
   role = aws_iam_role.taxon_indexing_concurrency_manager_role.arn
-
-  # Ensure the managed log group exists before the function can auto-create an implicit one.
-  depends_on = [aws_cloudwatch_log_group.taxon_indexing_concurrency_manager]
 }

--- a/terraform/modules/taxon-indexing-concurrency-manager/variables.tf
+++ b/terraform/modules/taxon-indexing-concurrency-manager/variables.tf
@@ -13,14 +13,5 @@ variable "index_taxon_lambda_name" {
   description = "Name of the index taxon lambda"
 }
 
-variable "log_retention_in_days" {
-  type        = number
-  default     = 90
-  description = "CloudWatch Logs retention in days for the concurrency-manager lambda log group (CZID-63)."
-}
-
-variable "log_kms_key_arn" {
-  type        = string
-  default     = null
-  description = "KMS key ARN to encrypt the concurrency-manager lambda log group (CZID-63). Null uses the AWS-managed key."
-}
+# log_retention_in_days / log_kms_key_arn were removed alongside the managed log group resource
+# (see the CZID-63 follow-up note in main.tf). Re-add them when the log group is re-adopted.


### PR DESCRIPTION
The CZID-63 managed log group blocks deploying the concurrency-manager lambda: dev's implicit group already exists (Lambda auto-created, no retention/KMS) so every apply hits ResourceAlreadyExistsException. Import needs a full plan (import blocks are skipped under `-target`), and a full dev apply is unsafe (52 add / 26 change / 12 destroy). Remove the managed group (+ the #17 import block, depends_on, unused vars) so the lambda's es_host code can deploy. Lambda still logs to the implicit group; re-adopt with retention+CMK as a tracked follow-up.