### PR TITLE
fix(taxon-indexing): CZID-63 managed log groups for the lambda family + import path

### DIFF
--- a/.github/workflows/import-log-groups.yml
+++ b/.github/workflows/import-log-groups.yml
@@ -1,0 +1,53 @@
+name: CypherID Workflow Infra Import Log Groups
+run-name: Import taxon-indexing log groups into ${{ inputs.environment }} state
+
+# CZID-63 one-time state adoption. The taxon-indexing worker / eviction / concurrency-manager
+# lambdas' CloudWatch log groups were auto-created by Lambda (no retention, no KMS) before they were
+# declared as terraform resources, so a plain apply hits ResourceAlreadyExistsException. A
+# declarative `import` block does not help because this repo deploys with -target, which skips import
+# blocks; and local `terraform import` is blocked by the archived template provider having no arm64
+# build (Rosetta timeout). This workflow runs `terraform import` on the Linux CI runner (no Rosetta
+# wall) via `make import-log-groups`, which is idempotent (skips any group already in state). After
+# it runs once, deploy the three modules (Deploy workflow, targets set) to reconcile retention + KMS.
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'The environment whose state to import the log groups into'
+        required: true
+        type: string
+        default: 'dev'
+
+env:
+  AWS_REGION: us-west-2
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DEPLOYMENT_ENVIRONMENT: ${{ inputs.environment }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  ImportLogGroups:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v6
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          # Same per-env apply role as the Deploy workflow: terraform import writes state (the
+          # backend S3 object) and reads the target log groups, both covered by czid_ci_cd.
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment }}-gh-actions-apply
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ env.AWS_REGION }}
+          aws-profile: idseq-${{ inputs.environment }}
+          output-env-credentials: true
+      - name: Sts GetCallerIdentity
+        run: |
+          aws sts get-caller-identity
+      - name: Import log groups
+        run: |
+          source scripts/init_ci_runner.sh
+          make import-log-groups

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,20 @@ deploy: package-lambdas templates init-tf
 	@if [[ $(DEPLOYMENT_ENVIRONMENT) == prod && $$(git symbolic-ref --short HEAD) != prod ]]; then echo Please deploy prod from the prod branch; exit 1; fi
 	terraform apply
 
+# CZID-63: one-time adoption of the taxon-indexing lambda log groups that Lambda auto-created before
+# they were declared as terraform resources. `terraform import` is required (a plain apply hits
+# ResourceAlreadyExistsException; an `import` block is skipped under -target). Idempotent -- skips any
+# group already in state. Run via the "Import Log Groups" GitHub workflow (Linux CI; local terraform
+# is blocked by the archived template provider on arm64). After importing, deploy the three modules
+# (targeted) to reconcile retention + KMS onto the imported groups.
+import-log-groups: package-lambdas templates init-tf
+	terraform state list | grep -qx 'module.idseq.module.taxon-indexing.aws_cloudwatch_log_group.taxon_indexing[0]' || \
+		terraform import 'module.idseq.module.taxon-indexing.aws_cloudwatch_log_group.taxon_indexing[0]' '/aws/lambda/taxon-indexing-lambda-$(DEPLOYMENT_ENVIRONMENT)-index_taxons'
+	terraform state list | grep -qx 'module.idseq.module.taxon-indexing-eviction.aws_cloudwatch_log_group.taxon_indexing_eviction[0]' || \
+		terraform import 'module.idseq.module.taxon-indexing-eviction.aws_cloudwatch_log_group.taxon_indexing_eviction[0]' '/aws/lambda/taxon-indexing-eviction-lambda-$(DEPLOYMENT_ENVIRONMENT)-evict'
+	terraform state list | grep -qx 'module.idseq.module.taxon-indexing-concurrency-manager.aws_cloudwatch_log_group.taxon_indexing_concurrency_manager' || \
+		terraform import 'module.idseq.module.taxon-indexing-concurrency-manager.aws_cloudwatch_log_group.taxon_indexing_concurrency_manager' '/aws/lambda/taxon-indexing-concurrency-manager-$(DEPLOYMENT_ENVIRONMENT)'
+
 # NOTE: moto errors on creating ssm parameters that begin with aws or ssm
 deploy-mock: templates package-lambdas
 	aws ssm put-parameter --name /mock-aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id --value ami-12345678 --type String --endpoint-url http://localhost:9000
@@ -64,4 +78,4 @@ clean:
 	git clean -fx .terraform.* test/.terraform.* terraform/chalice.tf.json terraform/modules/*/chalice.tf.json terraform/modules/*/*deployment.zip *-lambda/.chalice/deployments
 	rm -rf taxon-indexing-lambda/concurrency-manager/node_modules
 
-.PHONY: deploy deploy-mock plan templates init-tf package-lambdas lint clean
+.PHONY: deploy deploy-mock plan templates init-tf package-lambdas lint clean import-log-groups

--- a/terraform/idseq.tf
+++ b/terraform/idseq.tf
@@ -19,6 +19,9 @@ module "sfn-io-helper" {
 module "taxon-indexing" {
   source                 = "./modules/taxon-indexing"
   deployment_environment = var.DEPLOYMENT_ENVIRONMENT
+  # CZID-63: bound log retention + encrypt the worker lambda log group with the workflows CMK.
+  log_retention_in_days = var.lambda_log_retention_in_days
+  log_kms_key_arn       = aws_kms_key.workflows.arn
 }
 
 module "taxon-indexing-concurrency-manager" {
@@ -26,11 +29,15 @@ module "taxon-indexing-concurrency-manager" {
   deployment_environment  = var.DEPLOYMENT_ENVIRONMENT
   index_taxon_lambda_arn  = module.taxon-indexing.lambda_arn
   index_taxon_lambda_name = module.taxon-indexing.lambda_name
-  # CZID-63 log-group inputs (log_retention_in_days / log_kms_key_arn) removed with the managed log
-  # group resource -- see the follow-up note in the module's main.tf. Restore when re-adopted.
+  # CZID-63: bound log retention + encrypt the lambda log group with the workflows CMK.
+  log_retention_in_days = var.lambda_log_retention_in_days
+  log_kms_key_arn       = aws_kms_key.workflows.arn
 }
 
 module "taxon-indexing-eviction" {
   source                 = "./modules/taxon-indexing-eviction"
   deployment_environment = var.DEPLOYMENT_ENVIRONMENT
+  # CZID-63: bound log retention + encrypt the eviction lambda log group with the workflows CMK.
+  log_retention_in_days = var.lambda_log_retention_in_days
+  log_kms_key_arn       = aws_kms_key.workflows.arn
 }

--- a/terraform/modules/taxon-indexing-concurrency-manager/main.tf
+++ b/terraform/modules/taxon-indexing-concurrency-manager/main.tf
@@ -57,16 +57,19 @@ resource "aws_iam_role_policy" "taxon_indexing_concurrency_manager_role" {
   })
 }
 
-# NOTE (CZID-63 follow-up): a managed CloudWatch log group for this lambda was reverted. It was
-# declared for bounded retention + CMK encryption, but in dev Lambda had already auto-created the
-# implicit `/aws/lambda/taxon-indexing-concurrency-manager-dev` group (no retention, no KMS), so
-# every apply failed with ResourceAlreadyExistsException -- which blocked deploying this lambda at
-# all. Adopting the existing group needs `terraform import`, and a declarative `import` block only
-# takes effect in a FULL plan; this repo deploys with `-target` (which skips import blocks), and a
-# full dev apply is unsafe (a large, destroy-carrying backlog). So the managed group is removed here
-# to unblock lambda deploys. The lambda still logs to the implicit auto-created group. Re-adopt the
-# group with retention + the workflows CMK once the dev backlog is reconciled (via a full apply that
-# processes an import block, or a one-off `terraform import`). Tracked as a follow-up.
+# CloudWatch log group for the concurrency-manager lambda (CZID-63): bounded retention + CMK
+# encryption instead of the implicit never-expiring, unencrypted group Lambda auto-creates.
+# In dev the implicit group already exists, so it is adopted via `terraform import`
+# (make import-log-groups) before the first managing apply -- a plain apply would hit
+# ResourceAlreadyExistsException, and an `import` block does not help here (this repo deploys
+# with `-target`, which skips import blocks). depends_on orders it before the function so a fresh
+# env never lets Lambda auto-create the implicit group first.
+resource "aws_cloudwatch_log_group" "taxon_indexing_concurrency_manager" {
+  #checkov:skip=CKV_AWS_338:90-day retention (var.log_retention_in_days) is the deliberate cost/policy choice for this lambda log group; CKV_AWS_338 wants >=1 year. Logs are KMS-encrypted via the workflows CMK (var.log_kms_key_arn).
+  name              = "/aws/lambda/taxon-indexing-concurrency-manager-${var.deployment_environment}"
+  retention_in_days = var.log_retention_in_days
+  kms_key_id        = var.log_kms_key_arn
+}
 
 resource "aws_lambda_function" "taxon_indexing_concurrency_manager" {
   function_name    = "taxon-indexing-concurrency-manager-${var.deployment_environment}"
@@ -82,4 +85,7 @@ resource "aws_lambda_function" "taxon_indexing_concurrency_manager" {
     }
   }
   role = aws_iam_role.taxon_indexing_concurrency_manager_role.arn
+
+  # Ensure the managed log group exists before the function can auto-create an implicit one.
+  depends_on = [aws_cloudwatch_log_group.taxon_indexing_concurrency_manager]
 }

--- a/terraform/modules/taxon-indexing-concurrency-manager/variables.tf
+++ b/terraform/modules/taxon-indexing-concurrency-manager/variables.tf
@@ -13,5 +13,14 @@ variable "index_taxon_lambda_name" {
   description = "Name of the index taxon lambda"
 }
 
-# log_retention_in_days / log_kms_key_arn were removed alongside the managed log group resource
-# (see the CZID-63 follow-up note in main.tf). Re-add them when the log group is re-adopted.
+variable "log_retention_in_days" {
+  type        = number
+  default     = 90
+  description = "CloudWatch Logs retention in days for the concurrency-manager lambda log group (CZID-63)."
+}
+
+variable "log_kms_key_arn" {
+  type        = string
+  default     = null
+  description = "KMS key ARN to encrypt the concurrency-manager lambda log group (CZID-63). Null uses the AWS-managed key."
+}

--- a/terraform/modules/taxon-indexing-eviction/main.tf
+++ b/terraform/modules/taxon-indexing-eviction/main.tf
@@ -89,3 +89,17 @@ resource "aws_security_group" "taxon_indexing_eviction" {
     cidr_blocks = [data.aws_vpc.webservice_vpc[0].cidr_block]
   }
 }
+
+# CloudWatch log group for the taxon-indexing eviction lambda (CZID-63): bounded retention + CMK
+# encryption. Name matches the chalice-generated `evict` function
+# (/aws/lambda/taxon-indexing-eviction-lambda-<env>-evict). No depends_on (chalice-generated
+# lambda, not editable here); not needed -- see the equivalent note in modules/taxon-indexing.
+# Adopted in dev via `terraform import` (make import-log-groups) before the first managing apply.
+resource "aws_cloudwatch_log_group" "taxon_indexing_eviction" {
+  #checkov:skip=CKV_AWS_338:90-day retention (var.log_retention_in_days) is the deliberate cost/policy choice for this lambda log group; CKV_AWS_338 wants >=1 year. Logs are KMS-encrypted via the workflows CMK (var.log_kms_key_arn).
+  count = var.deployment_environment == "test" ? 0 : 1
+
+  name              = "/aws/lambda/taxon-indexing-eviction-lambda-${var.deployment_environment}-evict"
+  retention_in_days = var.log_retention_in_days
+  kms_key_id        = var.log_kms_key_arn
+}

--- a/terraform/modules/taxon-indexing-eviction/variables.tf
+++ b/terraform/modules/taxon-indexing-eviction/variables.tf
@@ -2,3 +2,15 @@ variable "deployment_environment" {
   type        = string
   description = "deployment environment: (test, dev, staging, prod, sandbox)"
 }
+
+variable "log_retention_in_days" {
+  type        = number
+  default     = 90
+  description = "CloudWatch Logs retention in days for the taxon-indexing eviction lambda log group (CZID-63)."
+}
+
+variable "log_kms_key_arn" {
+  type        = string
+  default     = null
+  description = "KMS key ARN to encrypt the taxon-indexing eviction lambda log group (CZID-63). Null uses the AWS-managed key."
+}

--- a/terraform/modules/taxon-indexing/main.tf
+++ b/terraform/modules/taxon-indexing/main.tf
@@ -97,3 +97,21 @@ resource "aws_security_group" "taxon_indexing" {
     cidr_blocks = [data.aws_vpc.webservice_vpc[0].cidr_block]
   }
 }
+
+# CloudWatch log group for the taxon-indexing worker lambda (CZID-63): bounded retention +
+# CMK encryption-at-rest, instead of the implicit never-expiring, unencrypted group Lambda
+# auto-creates. The name matches the chalice-generated function
+# (aws_lambda_function.index_taxons -> /aws/lambda/taxon-indexing-lambda-<env>-index_taxons).
+# No depends_on: the lambda is defined in the generated chalice.tf.json (not editable here). It
+# is not needed -- in a fresh env terraform creates this group before the lambda is ever invoked
+# (Lambda only auto-creates the implicit group on first invocation), so there is no create
+# conflict. In dev the group already exists (the lambda has run), so it is adopted via
+# `terraform import` (make import-log-groups) before the first apply that manages it.
+resource "aws_cloudwatch_log_group" "taxon_indexing" {
+  #checkov:skip=CKV_AWS_338:90-day retention (var.log_retention_in_days) is the deliberate cost/policy choice for this lambda log group; CKV_AWS_338 wants >=1 year. Logs are KMS-encrypted via the workflows CMK (var.log_kms_key_arn).
+  count = var.deployment_environment == "test" ? 0 : 1
+
+  name              = "/aws/lambda/taxon-indexing-lambda-${var.deployment_environment}-index_taxons"
+  retention_in_days = var.log_retention_in_days
+  kms_key_id        = var.log_kms_key_arn
+}

--- a/terraform/modules/taxon-indexing/variables.tf
+++ b/terraform/modules/taxon-indexing/variables.tf
@@ -2,3 +2,15 @@ variable "deployment_environment" {
   type        = string
   description = "deployment environment: (test, dev, staging, prod, sandbox)"
 }
+
+variable "log_retention_in_days" {
+  type        = number
+  default     = 90
+  description = "CloudWatch Logs retention in days for the taxon-indexing worker lambda log group (CZID-63)."
+}
+
+variable "log_kms_key_arn" {
+  type        = string
+  default     = null
+  description = "KMS key ARN to encrypt the taxon-indexing worker lambda log group (CZID-63). Null uses the AWS-managed key."
+}


### PR DESCRIPTION
Closes the CZID-63 gap for the whole taxon-indexing lambda family (worker + eviction + concurrency-manager) — all currently log to implicit, unencrypted, never-expiring groups.

## Changes
- Managed `aws_cloudwatch_log_group` (retention 90d + workflows CMK) in all three modules, named to each chalice function's group; wired via idseq.tf.
- New `make import-log-groups` + **Import Log Groups** workflow — runs `terraform import` on Linux CI. Needed because the existing groups must be **adopted, not created**: plain apply conflicts (ResourceAlreadyExists), a declarative `import{}` block is skipped under `-target` (what Deploy uses), and local terraform is Rosetta-blocked (archived template provider, no arm64). Idempotent.

## Rollout (dev)
merge → run **Import Log Groups** (env=dev) → **Deploy** with `targets` = the three modules to reconcile retention+KMS onto the imported groups. **No full apply** (dev backlog is 52 add / 26 change / 12 destroy).

Supersedes the #18 revert; fixes the root cause (repo had no import path).