### PR TITLE
fix(taxon-indexing): make OpenSearch clients survive node rotation (retry_on_timeout)

### DIFF
--- a/lambdas/taxon-indexing-eviction/chalicelib/es_queries.py
+++ b/lambdas/taxon-indexing-eviction/chalicelib/es_queries.py
@@ -12,7 +12,16 @@ logger.setLevel(logging.INFO)
 
 @functools.lru_cache(maxsize=None)
 def es():
-    return OpenSearch(config.get_parameters()["ES_HOST"], timeout=300)
+    # retry_on_timeout=True (opensearch-py defaults it to False) so a connect
+    # timeout to a rotated-out node ENI is retried onto a live node instead of
+    # failing the eviction run. czid-*-heatmap-es replaces nodes periodically.
+    # See platform-overhaul #723.
+    return OpenSearch(
+        config.get_parameters()["ES_HOST"],
+        timeout=300,
+        max_retries=3,
+        retry_on_timeout=True,
+    )
 
 
 def get_pipelines_being_deleted():

--- a/lambdas/taxon-indexing-eviction/test/test_es_queries.py
+++ b/lambdas/taxon-indexing-eviction/test/test_es_queries.py
@@ -1,0 +1,23 @@
+# type: ignore
+
+from chalicelib import es_queries
+
+
+class TestEsClientResilience:
+    def test_client_retries_on_timeout(self, mocker):
+        # Node rotation on czid-*-heatmap-es leaves warm containers dialing a dead
+        # ENI IP; without retry_on_timeout that connect-timeout fails the whole run.
+        # See platform-overhaul #723.
+        mocker.patch.object(
+            es_queries.config,
+            "get_parameters",
+            return_value={"ES_HOST": "test-es-host"},
+        )
+        es_queries.es.cache_clear()
+
+        client = es_queries.es()
+
+        assert client.transport.retry_on_timeout is True
+        assert client.transport.max_retries == 3
+
+        es_queries.es.cache_clear()

--- a/lambdas/taxon-indexing/app.py
+++ b/lambdas/taxon-indexing/app.py
@@ -18,13 +18,27 @@ logger.setLevel(logging.INFO)
 
 DEFAULT_ES_BATCHSIZE = 1000
 
+
+def build_os_client(host):
+    """
+    Build an OpenSearch client that survives node rotation. czid-*-heatmap-es is a
+    small zone-aware domain whose nodes are periodically replaced; when a node's ENI
+    IP changes, a warm Lambda container reusing a pooled connection dials the dead IP
+    and the connect times out. opensearch-py does NOT retry timeouts by default
+    (retry_on_timeout defaults to False), so that single dead-IP dial fails the whole
+    invocation. retry_on_timeout=True marks the dead connection and retries, which
+    re-resolves DNS onto a live node. See platform-overhaul #723.
+    """
+    return OpenSearch(host, timeout=120, max_retries=3, retry_on_timeout=True)
+
+
 if "AWS_CHALICE_CLI_MODE" not in os.environ:
     # Wire Sentry so unhandled Lambda errors (e.g. the heatmap ES timeout) reach
     # the same Sentry project as the Rails backend instead of dying silently in
     # CloudWatch.
     init_sentry()
     params = config.get_parameters()
-    es = OpenSearch(params["es_host"], timeout=120)
+    es = build_os_client(params["es_host"])
 
 
 def handler(event, context):
@@ -52,7 +66,7 @@ def index_taxons(event, context):
     # in the sandbox domain, never dev's. dev/staging/prod omit es_host and use the module-level
     # `es` client built from the DEPLOYMENT_ENVIRONMENT-configured host (unchanged behavior).
     es_host = event.get("es_host")
-    es_client = OpenSearch(es_host, timeout=120) if es_host else es
+    es_client = build_os_client(es_host) if es_host else es
 
     create_pipeline_run(
         pipeline_run_id, background_id, pipeline_runs_index_name, es_client


### PR DESCRIPTION
## What

Make the taxon-indexing worker and eviction lambdas' OpenSearch clients resilient to OpenSearch node rotation by adding `retry_on_timeout=True` + `max_retries=3`.

## Why

The dev-rails Sentry project has two recurring issues: `taxon-indexing-concurrency-manager-dev invocation failed ... N / 0 pipeline runs failed to index` (`elasticsearch_query_helper.rb:809`). Root cause, from the worker's own CloudWatch logs (07-19 19:21):

```
PUT .../pipeline_runs/_doc/3_26?refresh=true  [status:N/A request:30.6s]
TimeoutError: [Errno 110] Connection timed out
ConnectTimeoutError: Connection to vpc-czid-dev-heatmap-es-... timed out
```

- The worker builds its OpenSearch client **once at module scope** and reuses it across warm invocations with a persistent connection pool.
- `czid-dev-heatmap-es` is a 2-node zone-aware domain that **lost a node on 07-10 and 07-12** (`AWS/ES Nodes` metric Minimum=1). Node replacement gives a new ENI IP.
- When a node rotates, warm containers keep dialing the **dead IP → 30s connect-timeout**, failing every pipeline run in that batch until the container recycles.
- `opensearch-py` defaults `retry_on_timeout` to **False**, so that single dead-IP dial is fatal — it is never retried onto a live node.

Ruled out with evidence: AZ/subnet mismatch (lambda subnets are identical to the domain's) and SG block (domain SG allows the lambda's `10.132.0.0/16` range).

The fingerprint fits: bursty, whole-batch (`11 / 0`, `3 / 0`, `1 / 0` — never partial), across 3 releases, 0-1 users, self-healing.

## Change

- `taxon-indexing/app.py`: new `build_os_client(host)` helper (`timeout=120, max_retries=3, retry_on_timeout=True`), used for both the module-level `es` and the per-invocation sandbox `es_host` client.
- `taxon-indexing-eviction/chalicelib/es_queries.py`: same resilience kwargs on `es()` (keeps its `timeout=300`).
- New unit test asserting `transport.retry_on_timeout is True` + `max_retries == 3`.

With `retry_on_timeout=True`, a timed-out connection is dropped and retried; the reconnect re-resolves the domain DNS onto a currently-healthy node.

## Test

`lambdas/run_lambda_tests.sh` eviction suite: **39 passed** (38 existing + the new resilience test), against pinned `opensearch-py~=2.6.0`.

## Scope

Dev-observed, low-risk (adds retries; no happy-path behaviour change). The Rails `raise` and the concurrency-manager are behaving correctly and are unchanged. The underlying trigger (2-node domain losing nodes) is tracked separately as a sizing/stability follow-up. Tracked in platform-overhaul 723.
