### PR TITLE
fix(concurrency-manager): report failed/total and count hard failures as failures

### DIFF
--- a/.github/workflows/lambda-tests.yml
+++ b/.github/workflows/lambda-tests.yml
@@ -25,3 +25,20 @@ jobs:
           cache: pip
       - name: Run lambda unit tests
         run: bash lambdas/run_lambda_tests.sh
+
+  js-lambda-tests:
+    name: JS lambda unit tests (concurrency-manager)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install + test the concurrency-manager lambda
+        working-directory: lambdas/taxon-indexing-concurrency-manager
+        run: |
+          npm ci
+          npm test

--- a/lambdas/taxon-indexing-concurrency-manager/app.js
+++ b/lambdas/taxon-indexing-concurrency-manager/app.js
@@ -50,15 +50,38 @@ async function invoke_taxon_indexing(pipeline_run_ids, background_id, concurrenc
             ).catch(err => err) // catch errors so that we can return the results of all requests in the final response
         ), 
     )
-    result.map(x => x.Payload = new TextDecoder().decode(x.Payload))
-    const errorResults = result.filter((x => x.FunctionError))
-    const successResults = result.filter((x => !x.FunctionError))
+    const { errorResults } = classifyResults(result)
     if (errorResults.length > 0) {
         console.error(errorResults)
-        throw new Error(`${errorResults.length} / ${successResults.length} pipeline runs failed to index. See logs for more details.`)
+        throw new Error(failureMessage(errorResults.length, result.length))
     }
     return result
-    
+
+}
+
+// Split the Promise.all results into failures vs successes. Two failure shapes:
+// (1) a worker Lambda that threw returns a 200 InvokeCommand response with
+// FunctionError set; (2) an invocation that hard-failed after retries (network /
+// throttle) was caught above by `.catch(err => err)` and is a plain Error with no
+// FunctionError. BOTH are failures -- the previous `filter(x => !x.FunctionError)`
+// miscounted the hard failures as successes. Payload only exists on real
+// InvokeCommand responses, so only decode those. Exported for unit tests.
+// See platform-overhaul 724.
+export function classifyResults(results) {
+    results.forEach(x => {
+        if (!(x instanceof Error) && x.Payload) {
+            x.Payload = new TextDecoder().decode(x.Payload)
+        }
+    })
+    const errorResults = results.filter(x => x instanceof Error || x.FunctionError)
+    const successResults = results.filter(x => !(x instanceof Error) && !x.FunctionError)
+    return { errorResults, successResults }
+}
+
+// failed / TOTAL. The old message used failed/succeeded, so a fully-failed batch
+// printed "11 / 0" -- which reads as "11 of 0" instead of "11 of 11".
+export function failureMessage(failedCount, total) {
+    return `${failedCount} / ${total} pipeline runs failed to index. See logs for more details.`
 }
 
 async function invoke_lambda(payload) {

--- a/lambdas/taxon-indexing-concurrency-manager/app.test.js
+++ b/lambdas/taxon-indexing-concurrency-manager/app.test.js
@@ -1,0 +1,43 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { classifyResults, failureMessage } from './app.js'
+
+// A worker Lambda that threw: 200 response with FunctionError set.
+const functionError = () => ({ StatusCode: 200, FunctionError: 'Unhandled', Payload: new TextEncoder().encode('{"errorMessage":"boom"}') })
+// A successful worker invocation.
+const success = () => ({ StatusCode: 200, Payload: new TextEncoder().encode('{"success":true}') })
+// A hard invocation failure caught by `.catch(err => err)`: a plain Error.
+const hardError = () => new Error('ThrottlingException: rate exceeded')
+
+test('failureMessage reports failed / TOTAL, not failed / succeeded', () => {
+    // Regression for the "11 / 0" wording: a fully-failed batch of 11 must read 11 / 11.
+    assert.equal(failureMessage(11, 11), '11 / 11 pipeline runs failed to index. See logs for more details.')
+    assert.equal(failureMessage(1, 1), '1 / 1 pipeline runs failed to index. See logs for more details.')
+    assert.equal(failureMessage(3, 5), '3 / 5 pipeline runs failed to index. See logs for more details.')
+})
+
+test('classifyResults counts FunctionError responses as failures', () => {
+    const { errorResults, successResults } = classifyResults([functionError(), functionError()])
+    assert.equal(errorResults.length, 2)
+    assert.equal(successResults.length, 0)
+})
+
+test('classifyResults counts a hard Error (no FunctionError) as a failure, not a success', () => {
+    // The previous filter(x => !x.FunctionError) miscounted these as successes.
+    const { errorResults, successResults } = classifyResults([hardError(), success()])
+    assert.equal(errorResults.length, 1)
+    assert.equal(successResults.length, 1)
+})
+
+test('classifyResults splits a mixed batch correctly', () => {
+    const { errorResults, successResults } = classifyResults([success(), functionError(), hardError(), success()])
+    assert.equal(errorResults.length, 2)
+    assert.equal(successResults.length, 2)
+})
+
+test('classifyResults decodes Payload only on real responses, never on Error objects', () => {
+    const results = [success(), hardError()]
+    classifyResults(results)
+    assert.equal(typeof results[0].Payload, 'string')       // decoded
+    assert.ok(results[1] instanceof Error)                  // untouched, no crash
+})

--- a/lambdas/taxon-indexing-concurrency-manager/package.json
+++ b/lambdas/taxon-indexing-concurrency-manager/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## What

Fix two bugs in the taxon-indexing concurrency-manager's result handling, and give the JS lambda its first tests + CI coverage.

## Why

The dev-rails Sentry project's `taxon-indexing-concurrency-manager-dev invocation failed ... N / 0 pipeline runs failed to index` issues read as a paradox because of a message bug, and a latent counting bug hides real hard failures.

1. **`failed / SUCCEEDED` message** (`app.js:54`): a fully-failed batch printed `11 / 0` -- which reads as "11 of 0" instead of "11 of 11". Now `failed / TOTAL`.
2. **Hard failures miscounted as successes**: an invocation that hard-fails after retries is caught by `.catch(err => err)` as a plain `Error` with no `.FunctionError`, so `filter(x => !x.FunctionError)` counted it as a success. Now a result is a failure if it is an `Error` OR has `FunctionError`; `Payload` is decoded only on real `InvokeCommand` responses (guards the `Error` case, which also fixes a latent `TextDecoder().decode(undefined)` on error objects).

## Change

- Extract classification + message into exported pure functions `classifyResults()` / `failureMessage()`.
- New `app.test.js` (`node:test`, 5 tests) covering the wording regression, FunctionError failures, the hard-Error-is-a-failure case, mixed batches, and Payload-decode safety.
- `package.json` `test` -> `node --test`.
- New `js-lambda-tests` job in `lambda-tests.yml` -- the JS lambda had no tests and no CI coverage (same rot risk the Python suites were rescued from).

## Test

`npm test` in `lambdas/taxon-indexing-concurrency-manager`: **5 passed** (node v20+).

## Scope

Dev-only, low risk. No happy-path behaviour change -- a fully-successful batch still returns `result` and never throws. Pairs with the worker-resilience fix (separate PR) that addresses the underlying cause of these failures. Tracked in platform-overhaul 724.
