### PR TITLE
ci: add pytest coverage floor to lambda-tests (#749)

### DIFF
--- a/lambdas/run_lambda_tests.sh
+++ b/lambdas/run_lambda_tests.sh
@@ -21,11 +21,29 @@ echo ">> interpreter: $("$PY" --version 2>&1)"
 # The suites are pure (no live AWS); the sfn-io-helper and cloudwatch-alerting
 # suites cover only chalicelib logic that never imports the chalice framework,
 # so they are unaffected by the chalice/py312 packaging blocker (CZID-443).
+#
+# Each suite carries a per-suite line-coverage FLOOR (CZID-749). The floor is a
+# RATCHET, not an aspiration: it is set one point BELOW the coverage measured at
+# the time it was introduced, so it only ever fails a change that REMOVES covered
+# code without covering it (a regression), mirroring seqtoid-web's coverage
+# philosophy. Coverage is scoped to `chalicelib` (the unit-testable package);
+# `app.py` imports the chalice framework and is never imported by these unit
+# suites, so including it would only add spurious 0% noise. The absolute numbers
+# are low because untested boilerplate lives in-package (sentry_init.py,
+# es_queries.py, batch_events.py, reporting.py); raising them is future work,
+# but the floor guarantees they cannot silently drop. To raise a floor, measure
+# the new coverage and set the floor one point below it.
+#
+# TESTED and FLOORS are parallel arrays: FLOORS[i] is the floor for TESTED[i].
 TESTED=(taxon-indexing-eviction sfn-io-helper cloudwatch-alerting)
+FLOORS=(61                      14            22)
 
 rc=0
+i=0
 for d in "${TESTED[@]}"; do
-  echo ">> testing: $d"
+  floor="${FLOORS[$i]}"
+  i=$((i + 1))
+  echo ">> testing: $d (coverage floor: ${floor}%)"
   venv="$(mktemp -d)/v"
   "$PY" -m venv "$venv"
   # shellcheck disable=SC1091
@@ -35,12 +53,15 @@ for d in "${TESTED[@]}"; do
   # tracked separately under SEQTOID-131) plus the test tooling.
   reqs="$(mktemp)"
   grep -v '^chalice' "$d/requirements.txt" > "$reqs" || true
-  pip install -q -r "$reqs" pytest pytest-mock
+  pip install -q -r "$reqs" pytest pytest-mock pytest-cov
   # config.py reads DEPLOYMENT_ENVIRONMENT at import; the suite mocks SSM/params
   # itself, so the single var is all the unit tests need (don't source
-  # environment.test — it makes live aws sts/iam calls).
+  # environment.test -- it makes live aws sts/iam calls).
+  # --cov-fail-under makes pytest exit non-zero if coverage drops below the floor.
   ( cd "$d" && DEPLOYMENT_ENVIRONMENT=test AWS_DEFAULT_REGION=us-west-2 \
-      python -m pytest test/ -q ) || rc=1
+      python -m pytest test/ -q \
+        --cov=chalicelib --cov-report=term-missing \
+        --cov-fail-under="$floor" ) || rc=1
   deactivate
 done
 


### PR DESCRIPTION
## What

Adds a per-suite line-coverage ratchet to the Chalice lambda unit harness so lambda coverage cannot silently regress. Implements audit finding **#749** (coverage floor) for this repo.

`lambda-tests.yml` wired the lambda unit suites into CI but with **no coverage gate**, so any change that deleted covered code (or a test) would go green. This adds a `--cov-fail-under` floor.

## Measured coverage and chosen floors

Coverage measured locally with `pytest --cov=chalicelib` on each tested suite. Floors are set **one point below measured** -- a ratchet that only fails a regression, not an aspirational target (mirrors seqtoid-web's philosophy):

| suite | measured | floor |
| --- | --- | --- |
| taxon-indexing-eviction | 62% | 61% |
| sfn-io-helper | 15% | 14% |
| cloudwatch-alerting | 23% | 22% |

The low absolute numbers reflect **untested in-package boilerplate** (`sentry_init.py`, `es_queries.py`, `batch_events.py`, `reporting.py`) that these pure unit suites do not exercise. The ratchet's job is to stop coverage dropping further; raising it is future work (a follow-up can bump each floor after adding tests).

## Where

The floor lives in `lambdas/run_lambda_tests.sh` (which `lambda-tests.yml` already invokes), so it enforces **identically in CI and locally** -- one source of truth, no workflow YAML change needed. `pytest-cov` is added to the harness's pip install. Coverage is scoped to `chalicelib`; `app.py` imports the chalice framework and is never imported by these unit suites, so including it would add only spurious 0% noise.

## Validation

- `bash lambdas/run_lambda_tests.sh` passes all three suites, each with a ~1-point buffer above its floor.
- `shellcheck` clean; ASCII-only.

For review -- do not auto-merge.
