### PR TITLE
ci: workflow-infra CD hygiene -- plan->reviewed-apply linkage (#751)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,29 @@
 name: CypherID Workflow Infra Deploy
-run-name: Deploy CypherID Workflow Infra to ${{ inputs.environment }}
+run-name: Deploy CypherID Workflow Infra to ${{ inputs.environment }}${{ inputs.plan-run-id && format(' (reviewed plan from run {0})', inputs.plan-run-id) || '' }}
+
+# CD HYGIENE (CZID-751). This workflow supports two apply paths, chosen by whether
+# plan-run-id is supplied:
+#
+#   1. LEGACY path (plan-run-id EMPTY, the default -- behavior UNCHANGED):
+#      `make deploy` runs `terraform apply` with TF_CLI_ARGS_apply=--auto-approve
+#      and NO plan linkage, so it applies whatever the live config wants at run
+#      time. This is the pre-existing behavior; it is left intact so nothing
+#      that relies on it breaks.
+#
+#   2. REVIEWED-APPLY path (plan-run-id SET -- OPT-IN, off by default):
+#      Downloads the exact `tf.plan` artifact produced by a prior "Plan only"
+#      run (plan_only.yml -> plan_call.yml) and runs `terraform apply tf.plan`.
+#      terraform applies ONLY the frozen, reviewed diff and refuses the saved
+#      plan outright if state has moved since it was generated. This mirrors
+#      web-infra's plan_all/apply_all run-id linkage model.
+#
+# Neither path auto-applies: both are workflow_dispatch, human-triggered. This
+# change adds path 2 as INERT/opt-in and does NOT enable any automatic apply.
+#
+# CAUTION: workflow-infra has a large pending-change backlog (see CZID-708, ~92
+# changes). Do NOT run a full apply of this repo blindly on either path. Review
+# the "Plan only" summary first; for the reviewed-apply path, pass that run's id
+# so the apply is exactly what was reviewed.
 
 on:
   workflow_dispatch:
@@ -16,7 +40,16 @@ on:
           plan-linkage, so it applies whatever the config wants at run time; scoping it is how a
           narrow change gets applied without dragging along unrelated pending drift. Plan the same
           targets with the "Plan only" workflow first and confirm the diff. Leave empty for a full
-          apply.
+          apply. IGNORED when plan-run-id is set (the reviewed plan already fixes its own scope).
+        required: false
+        type: string
+        default: ''
+      plan-run-id:
+        description: >-
+          OPT-IN reviewed-apply. Leave EMPTY (default) for the legacy make-deploy apply. Set it to
+          the GitHub Actions run id of a completed "Plan only" run to apply that run's exact,
+          reviewed tf.plan instead -- terraform applies only that frozen diff and refuses it if
+          state has drifted since. This is the safer, plan-linked path.
         required: false
         type: string
         default: ''
@@ -32,10 +65,15 @@ permissions:
 
 jobs:
   DeployTerraform:
+    name: Legacy apply (make deploy, --auto-approve)
+    # Runs ONLY when no plan-run-id is supplied, i.e. the default. This is the
+    # pre-existing path, left untouched; the opt-in reviewed-apply job below runs
+    # instead when a plan-run-id is given, so exactly one of the two ever runs.
+    if: ${{ inputs.plan-run-id == '' }}
     runs-on: ubuntu-latest
     # C4: gate the deploy by the GitHub Environment so prod requires the reviewer
     # approval configured on the Environment (protection rules land with #81). Was
-    # ungated — an auto-approve `terraform apply` behind only a shell branch/account
+    # ungated -- an auto-approve `terraform apply` behind only a shell branch/account
     # guard, with no environment: and no plan-linkage.
     environment: ${{ inputs.environment }}
     steps:
@@ -94,3 +132,102 @@ jobs:
           echo "TF_CLI_ARGS_apply=$TF_CLI_ARGS_apply"
 
           make deploy
+
+  ApplyReviewedPlan:
+    name: Reviewed apply (plan->apply linkage, opt-in)
+    # OPT-IN reviewed-apply path (CZID-751). Runs ONLY when a plan-run-id is
+    # supplied; DeployTerraform above runs when it is empty, so this workflow's
+    # default behavior is unchanged and this job is inert unless a reviewer
+    # deliberately passes a plan run id. It applies the EXACT tf.plan artifact
+    # from that "Plan only" run rather than make deploy's --auto-approve apply of
+    # whatever the live config wants -- terraform refuses a saved plan if state
+    # has moved since it was generated, so the reviewer approves a frozen diff.
+    if: ${{ inputs.plan-run-id != '' }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 matches plan_call.yml.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Reconfigure Git to use HTTP authentication
+        run: |
+          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+      - name: Install AWS CLI
+        uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # v1
+        with:
+          version: 2
+          verbose: false
+          arch: amd64
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          # Same per-env least-privilege apply role and profile as the legacy job.
+          # See the DeployTerraform job for why aws-profile is load-bearing.
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment }}-gh-actions-apply
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ env.AWS_REGION }}
+          aws-profile: idseq-${{ inputs.environment }}
+          output-env-credentials: true
+      - name: Sts GetCallerIdentity
+        run: |
+          aws sts get-caller-identity
+      - name: Read Terraform version (SSOT = .terraform-version)
+        id: tfver
+        run: echo "version=$(cat .terraform-version)" >> "$GITHUB_OUTPUT"
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ steps.tfver.outputs.version }}
+          terraform_wrapper: false
+      - name: Setup Terraform Environment
+        # Mirror plan_call.yml: source environment.<env> and forward the variables
+        # terraform needs (TF_DATA_DIR, TF_CLI_ARGS_init pointing at the S3 backend,
+        # etc.) to later steps. Every run: block is its own shell, so this must be
+        # forwarded via $GITHUB_ENV. AWS credentials are NOT forwarded here --
+        # configure-aws-credentials already published them.
+        run: |
+          set -x
+          source "environment.${{ inputs.environment }}"
+          set +x
+          echo "TF_DATA_DIR=$TF_DATA_DIR"
+          mkdir -p "$TF_DATA_DIR"
+          jq -n ".region=\"us-west-2\" | .bucket=env.TF_S3_BUCKET | .key=env.APP_NAME+env.DEPLOYMENT_ENVIRONMENT | .encrypt=true" > "$TF_DATA_DIR/aws_config.json"
+          jq . "$TF_DATA_DIR/aws_config.json"
+          for v in APP_HOME APP_NAME DEPLOYMENT_ENVIRONMENT TF_DATA_DIR TFSTATE_FILE \
+                   TF_CLI_ARGS_init TF_CLI_ARGS_output AWS_SDK_LOAD_CONFIG AWS_DEFAULT_REGION \
+                   AWS_ACCOUNT_ID AWS_ACCOUNT_ALIAS TF_S3_BUCKET DOCKER_REGISTRY \
+                   OWNER TF_VAR_owner TF_VAR_environment; do
+            printf '%s=%s\n' "$v" "${!v}" >> "$GITHUB_ENV"
+          done
+      - name: Package Lambdas and create Templates
+        # The saved plan references locally generated artifacts (lambda zips,
+        # chalice.tf.json, rendered templates). Regenerate them exactly as the plan
+        # run did so `terraform apply tf.plan` sees the same files. If a generated
+        # artifact is not byte-reproducible, terraform will reject the saved plan as
+        # stale -- which fails safe (it will not apply an unreviewed diff).
+        run: |
+          make package-lambdas templates
+      - name: Download the reviewed plan artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: plan
+          path: ${{ github.workspace }}
+          run-id: ${{ inputs.plan-run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Terraform Init and Apply the reviewed plan
+        run: |
+          terraform init -input=false
+          if [[ ! -f "${{ github.workspace }}/tf.plan" ]]; then
+            echo "::error::No tf.plan artifact found for run ${{ inputs.plan-run-id }}. Run a 'Plan only' for this environment and pass its run id."
+            exit 1
+          fi
+          echo "Applying the reviewed plan from run ${{ inputs.plan-run-id }}."
+          echo "terraform will refuse this saved plan if state has drifted since it was generated."
+          # No --auto-approve: a saved plan file is applied without a prompt by
+          # definition, and only the changes it froze -- never a fresh diff of the
+          # live config.
+          terraform apply -input=false "${{ github.workspace }}/tf.plan"


### PR DESCRIPTION
## What

Adds an **opt-in** plan->reviewed-apply linkage to `deploy.yml`, implementing audit finding **#751** (CD hygiene) for this repo. This is a **proposal for review** -- it changes no default behavior and enables **no automatic apply**.

## Problem

`deploy.yml` is `workflow_dispatch`-only and applies via `make deploy`, which runs `terraform apply` with `TF_CLI_ARGS_apply=--auto-approve` and **no plan linkage**. The person who triggers it approves *an action*, not a *specific reviewed diff* -- terraform applies whatever the live config wants at dispatch time. There is no artifact tying the apply to a plan a reviewer looked at.

## Design (mirrors web-infra's `plan_all`/`apply_all` run-id model)

A new optional input `plan-run-id` selects the path; exactly one job runs:

| `plan-run-id` | Job | Behavior |
| --- | --- | --- |
| **empty (default)** | `DeployTerraform` | **Unchanged.** `make deploy`, `--auto-approve`, as today. |
| **set** | `ApplyReviewedPlan` | Downloads the exact `tf.plan` artifact from that "Plan only" run and runs `terraform apply tf.plan`. |

The reviewed-apply path:
- applies **only the frozen diff** the reviewer saw in the Plan only summary;
- **refuses the saved plan** if state has drifted since it was generated (terraform's built-in staleness check) -- so a stale plan **fails safe** instead of applying an unreviewed change;
- uses **no `--auto-approve`** (a saved plan is applied without a fresh diff by definition);
- reuses the same per-env apply role, profile, and terraform-env setup as the existing paths (mirrors `plan_call.yml`).

## Why it is safe (inert / opt-in)

- The two jobs are **mutually exclusive** on `plan-run-id`. With the input empty (the default), only the legacy job runs and does exactly what it does today -- **this change is inert unless a reviewer deliberately opts in**.
- **Neither path auto-applies.** Both remain `workflow_dispatch`, human-triggered. No `push`/`workflow_run` trigger is added.
- The legacy path is left fully intact, so nothing that depends on it breaks.

## Must not be applied blindly

Per memory/#708, **workflow-infra has never been applied on the IT-ARS account and carries a large pending-change backlog (~92 changes)**. A full apply of *either* path would drag in that backlog. This PR does **not** run any apply; it only adds the safer path. Any real apply must first review the "Plan only" summary, and for the reviewed path, pass that run's id so the apply is exactly what was reviewed.

## Caveat noted in-workflow

The saved plan references locally generated artifacts (lambda zips, `chalice.tf.json`, rendered templates). The apply job regenerates them with `make package-lambdas templates` before applying; if a generated artifact is not byte-reproducible, terraform rejects the saved plan as stale -- which fails safe. This is called out in a comment for reviewers to weigh.

## Validation

- `actionlint` clean; YAML parses; ASCII-only.
- Not executed against AWS (by design -- see backlog caution above).

For review -- do not merge or apply blindly.
