### PR TITLE
feat(buckets): per-account reference bucket name override (generate-once prereq)

### DIFF
--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -1,8 +1,43 @@
+# Per-account reference bucket name (generate-once -> replicate prerequisite).
+#
+# The reference (NT/NR taxon index) bucket used to be a single, hardcoded,
+# globally-unique name "seqtoid-public-references". A global-unique S3 name can
+# exist in exactly ONE account, so it collides with the program rule that each
+# env is self-sufficient in its OWN account (no cross-account providers, no one
+# shared bucket read across accounts). To replicate byte-identical index
+# artifacts INTO each env, every env needs its own uniquely-named reference
+# bucket -- mirroring how s3_bucket_workflows is already per-account.
+#
+# This variable lets each env supply its own name WITHOUT breaking the live dev
+# path: the default is empty, which resolves to the legacy global name below, so
+# a `terraform plan` with the var unset is byte-identical to before (no drift,
+# nothing destroyed). Envs migrate one at a time by (1) creating + seeding their
+# own bucket out-of-band, (2) setting this var to that name, (3) applying. See
+# LEVER1-GENERATE-ONCE-REPLICATE-DESIGN.md for the full migration + replication
+# flow. NOTE: index-generation.tf still hardcodes the legacy ARN in one IAM
+# statement; that must be repointed to this local as part of the same migration
+# (tracked separately -- that file is owned by the CE spot-params change).
+variable "PUBLIC_REFERENCES_BUCKET_NAME" {
+  description = "Override for the per-account reference (taxon index) bucket name. Empty (default) resolves to the legacy global name 'seqtoid-public-references' so existing envs are unchanged. Per-account envs should set this to a unique name, recommended 'seqtoid-public-references-<env>-<account-id>'."
+  type        = string
+  default     = ""
+}
+
 locals {
   # TODO: Where else to put these, possibly env-specific, configurations?
   # s3_bucket_workflows         = "cypherid-samples-deleteme"
-  s3_bucket_workflows         = "seqtoid-workflows-${var.DEPLOYMENT_ENVIRONMENT}-${var.AWS_ACCOUNT_ID}"
-  s3_bucket_public_references = "seqtoid-public-references"
+  s3_bucket_workflows = "seqtoid-workflows-${var.DEPLOYMENT_ENVIRONMENT}-${var.AWS_ACCOUNT_ID}"
+
+  # Recommended per-account name for envs that adopt their own reference bucket.
+  # Not applied automatically (that would change the live data-source lookup and
+  # break the current shared bucket); an env opts in by setting
+  # var.PUBLIC_REFERENCES_BUCKET_NAME. Kept here as the canonical pattern so all
+  # envs converge on the same shape once migrated.
+  s3_bucket_public_references_per_account = "seqtoid-public-references-${var.DEPLOYMENT_ENVIRONMENT}-${var.AWS_ACCOUNT_ID}"
+
+  # Effective name: explicit override wins; otherwise the legacy global name so
+  # the current dev/staging/prod path is unchanged (byte-identical plan).
+  s3_bucket_public_references = var.PUBLIC_REFERENCES_BUCKET_NAME != "" ? var.PUBLIC_REFERENCES_BUCKET_NAME : "seqtoid-public-references"
 
   # DATA-1 (CZID-31): allow terraform to destroy data resources only in throwaway envs;
   # protect the shared/long-lived envs (staging/prod) from a silent destroy/replace data loss.
@@ -10,7 +45,11 @@ locals {
 }
 
 # TODO: Create one bucket per environment? Or one bucket per version?
-#  Either way, we need to have the bucket owned by Terraform in some Environment; currently it's manually created and managed
+#  Either way, we need to have the bucket owned by Terraform in some Environment; currently it's manually created and managed.
+#  This stays a data source (not a TF-owned resource) on purpose: the reference
+#  bucket is large and live, and converting it to a managed resource risks a
+#  destroy/recreate of many TB of taxon indexes. Per-account TF ownership is a
+#  later, deliberately-scoped apply (see LEVER1-GENERATE-ONCE-REPLICATE-DESIGN.md).
 data "aws_s3_bucket" "public-references" {
   bucket = local.s3_bucket_public_references
 }


### PR DESCRIPTION
## What

Make the reference (NT/NR taxon index) bucket name per-account/per-env unique, without breaking the live path. This is the naming prerequisite for the "generate-once -> replicate" foundation (Lever 1): build the index once, verify it, then copy the immutable `ncbi-indexes-<date>/` artifacts into each env's own reference bucket.

## Why

`local.s3_bucket_public_references` was a single, hardcoded, globally-unique name (`seqtoid-public-references`). A global-unique S3 name can exist in exactly one account, which collides with the program rule that each env is self-sufficient in its own account (no cross-account providers, no one shared bucket read across accounts). To replicate byte-identical artifacts into each env, every env needs its own uniquely-named reference bucket, mirroring how `s3_bucket_workflows` is already per-account (`seqtoid-workflows-<env>-<account>`).

## Change

- New variable `PUBLIC_REFERENCES_BUCKET_NAME` (string, default `""`).
- `local.s3_bucket_public_references` = override if set, else the legacy global name.
- New `local.s3_bucket_public_references_per_account` documents the recommended pattern `seqtoid-public-references-<env>-<account-id>`.
- Expanded comments recording the migration path and why the bucket stays a data source.

## Non-destructive by design (what this deliberately does NOT do)

- Default is empty, which resolves to the legacy global name, so `terraform plan` with the var unset is byte-identical to before: no drift, nothing destroyed.
- The bucket stays a `data` source. It is NOT converted to a TF-owned `aws_s3_bucket` resource, because that would risk a destroy/recreate of live multi-TB taxon-index artifacts. Per-account TF ownership is a later, deliberately-scoped apply.
- The one hardcoded legacy ARN in the index-generation IAM statement is intentionally left untouched here (that file is owned by a separate in-flight change); repointing it to this local is part of the same per-env migration and is documented in the design doc.

## Migration (per env, one at a time)

1. Create + seed the env's own per-account bucket out-of-band (the replicate step of generate-once -> replicate).
2. Set `PUBLIC_REFERENCES_BUCKET_NAME` to that name (recommended `seqtoid-public-references-<env>-<account-id>`).
3. Apply. The data-source lookup then resolves to the per-account bucket.

Full flow (build account -> SHA256 manifest -> AUPR >= 0.98 gate -> S3 copy into each env -> post-copy re-verify -> blue/green flip) is in the generate-once/replicate design doc.

## Validation

- `terraform fmt -check` clean.
- Additions are ASCII-only.
- Plan is unchanged when the var is unset (byte-identical to the current shared-bucket path).
