### PR TITLE
fix(index-generation): drop invalid spot-only params from on-demand Batch CE

### DIFF
--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -148,10 +148,15 @@ resource "aws_batch_compute_environment" "index_generation_compute_environment" 
 
     subnets = length(data.aws_subnets.webservice_subnets) > 0 ? data.aws_subnets.webservice_subnets[0].ids : [for subnet in aws_subnet.idseq : subnet.id]
 
+    // On-demand compute. index-generation is currently ONE monolithic multi-hour
+    // miniwdl job on a single host, so a spot interruption would kill the whole
+    // rebuild -- spot is not safe here yet. bid_percentage and spot_iam_fleet_role
+    // are SPOT-only attributes; with type = "EC2" Terraform silently ignored them
+    // and the CE has always run on-demand, so removing them is non-regressive.
+    // Spot belongs later on the per-chunk indexing fan-out, where interruptions
+    // are cheap and checkpointable, not on this monolithic job.
     type                = "EC2"
     allocation_strategy = "BEST_FIT"
-    bid_percentage      = 100
-    spot_iam_fleet_role = aws_iam_role.idseq_batch_spot_fleet_service_role.arn
 
     launch_template {
       launch_template_name = aws_launch_template.index_generation_launch_template.name


### PR DESCRIPTION
## What

The `index_generation_compute_environment` AWS Batch compute environment in
`terraform/index-generation.tf` is declared `type = "EC2"` (on-demand) but
carried two SPOT-only attributes:

```
bid_percentage      = 100
spot_iam_fleet_role = aws_iam_role.idseq_batch_spot_fleet_service_role.arn
```

Terraform accepts this config, but `bid_percentage` and `spot_iam_fleet_role`
are only meaningful when `type = "SPOT"`. With `type = "EC2"` they are silently
ignored, so the CE has always launched **on-demand** instances. The result is a
latent cost bug: the index-generation heavy phases have been billed at
on-demand rates while the NT/NR optimization cost plan assumed "100% spot".

This PR removes the two invalid attributes so the CE is **explicitly and
validly on-demand**, and adds a short comment explaining why spot is deferred.

## Why this is non-regressive

The CE already runs on-demand today (the spot params were no-ops under
`type = "EC2"`). Removing them changes no runtime behavior -- it only makes the
config say what it actually does. `terraform plan` on this change is expected to
show no change to the launched instance type/pricing.

The shared spot fleet IAM role (`idseq_batch_spot_fleet_service_role`) is left
untouched -- it is still referenced by the alignment spot workloads
(`terraform/alignment.tf` and the `scalable-alignment-batch` module), so this is
purely a de-reference from one CE, not a resource removal.

## Spot vs on-demand: recommendation

Recommendation: **stay on-demand for this CE now**, and leave the spot-vs-
on-demand cost call to a deliberate future decision rather than flipping it in
this fix.

Rationale -- I evaluated the `type = "SPOT"` /
`allocation_strategy = "SPOT_CAPACITY_OPTIMIZED"` alternative:

- index-generation today is **one monolithic, multi-hour miniwdl job** that runs
  all tasks on a single host. It is not yet fanned out into independent chunks.
- A spot interruption on a monolithic multi-hour job kills the **entire**
  rebuild, forcing a full restart. There is no checkpoint/restart story on this
  job today, so the expected cost of interruptions (wasted multi-hour compute +
  wall-clock delay on a rebuild) can easily exceed the spot discount.
- Spot is the right tool one stage later, on the **per-chunk indexing fan-out**
  (the Graviton spot fan-out work), where each unit is small, cheap to retry,
  and interruptions are recoverable. That is where the cost plan's spot savings
  should actually be realized.

So flipping this CE to spot would trade a modest hourly discount for the risk of
losing a whole multi-hour rebuild -- not a safe default. If we later decide the
interruption risk is acceptable (or add checkpointing), switching to
`type = "SPOT"` with `allocation_strategy = "SPOT_CAPACITY_OPTIMIZED"` is a
small follow-up; the shared spot fleet IAM role is already in place. Leaving the
final cost call to Tom.

## Validation

- `terraform fmt -check` clean on the changed file.
- Full offline `terraform validate` is blocked by a pre-existing repo
  prerequisite unrelated to this change: the root config uses symlinked module
  directories that are generated by `make package-lambdas` (chalice codegen),
  which CI runs before validate. Provider init itself did not hang and reported
  zero HCL/schema errors against the edited file. CI's `Terraform Validate` job
  runs the full `prepare` + `init -backend=false` + `validate` flow and is the
  authoritative gate here.
- Diff is scoped to removing the two invalid attributes plus an explanatory
  comment; no other resource or behavior is touched.

## Coordination

`terraform/index-generation.tf` is also touched by two held PRs -- the Lever-1
x86 right-size PR and the Lever-2 Graviton PR. This small correctness fix is
intended to merge **first**; both of those will need a trivial rebase on top
(the conflict is limited to the same CE block).

Tracked in the workflow-infra tracker (index-generation CE spot-params bug).
