### PR TITLE
feat(reference-index): blue/green + backups + rollback for the NT/NR sequence DB (Lever-1 GR-7)

### DIFF
--- a/scripts/reference_index_promote.sh
+++ b/scripts/reference_index_promote.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# reference_index_promote.sh -- blue/green PROMOTE for the NT/NR sequence index.
+#
+# The sequence-DB mirror of the lineage `rake taxonomy:cutover`: flip the
+# "current index version" SSM pointer to a new dated version so NEW pipeline runs
+# resolve to it. Instant and fully reversible (reference_index_rollback.sh flips
+# back). The previous version is saved to the previous-version pointer first, so
+# rollback is a single atomic flip.
+#
+# FAIL-CLOSED AUPR GATE (mirrors the lineage "benchmark AUPR >= 0.98 before
+# cutover" rule): promotion refuses unless an AUPR-PASS marker exists for the
+# EXACT version being promoted. That marker is written by the benchmark gate
+# (design phase GR-6), keyed on <version>/<major> so a stale pass cannot
+# green-light a different build. GR-6's marker producer is not built yet, so
+# today this gate blocks until the marker is written by hand or by GR-6; set
+# ALLOW_UNVERIFIED=1 ONLY for a documented dev dry-run. NOTHING here builds or
+# copies an index -- it only flips the pointer once the artifacts + gate exist.
+#
+# Usage:
+#   DEPLOYMENT_ENVIRONMENT=dev scripts/reference_index_promote.sh 2026-08-01
+#   AWS_REGION=us-west-2 DEPLOYMENT_ENVIRONMENT=dev scripts/reference_index_promote.sh 2026-08-01
+#
+# Env:
+#   DEPLOYMENT_ENVIRONMENT  (required)  which env's pointer to flip
+#   AWS_REGION              (optional)  defaults to us-west-2
+#   ALLOW_UNVERIFIED        (optional)  "1" bypasses the AUPR-PASS marker (dev dry-run only)
+
+set -euo pipefail
+
+if [[ $# != 1 ]]; then
+    echo "Promote (blue/green cutover) the NT/NR sequence index to a new version."
+    echo
+    echo "Usage: $(basename "$0") <new-version>"
+    echo "Example: DEPLOYMENT_ENVIRONMENT=dev $(basename "$0") 2026-08-01"
+    exit 1
+fi
+
+NEW_VERSION="$1"
+: "${DEPLOYMENT_ENVIRONMENT:?set DEPLOYMENT_ENVIRONMENT (dev|staging|prod|sandbox)}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+PREFIX="/seqtoid/${DEPLOYMENT_ENVIRONMENT}/reference-index"
+
+ssm_get() { aws ssm get-parameter --region "$AWS_REGION" --name "$1" --query 'Parameter.Value' --output text; }
+ssm_put() { aws ssm put-parameter --region "$AWS_REGION" --name "$1" --value "$2" --type String --overwrite >/dev/null; }
+
+CURRENT="$(ssm_get "${PREFIX}/current-version")"
+MAJOR="$(ssm_get "${PREFIX}/major-version")"
+
+if [[ "$CURRENT" == "$NEW_VERSION" ]]; then
+    echo "[promote] current is already '${NEW_VERSION}'; nothing to do."
+    exit 0
+fi
+
+# --- AUPR-PASS gate (fail-closed) --------------------------------------------
+# The marker is an SSM parameter the benchmark gate (GR-6) writes on a passing
+# per-sample AUPR >= 0.98 run, keyed on the exact version+major being promoted.
+MARKER="${PREFIX}/aupr-pass/index-generation-${MAJOR}/${NEW_VERSION}"
+if [[ "${ALLOW_UNVERIFIED:-}" == "1" ]]; then
+    echo "[promote] WARNING: ALLOW_UNVERIFIED=1 -- skipping the AUPR-PASS gate (dev dry-run only)."
+else
+    if ! MARKER_VAL="$(ssm_get "$MARKER" 2>/dev/null)"; then
+        echo "[promote] REFUSED: no AUPR-PASS marker at ${MARKER}" >&2
+        echo "  The benchmark gate (design phase GR-6) must record a passing AUPR >= 0.98 run for" >&2
+        echo "  index-generation-${MAJOR}/${NEW_VERSION} before it can be promoted. Fail-closed." >&2
+        exit 2
+    fi
+    echo "[promote] AUPR-PASS marker present for ${NEW_VERSION} (${MARKER_VAL})."
+fi
+
+echo "[promote] flipping current NT/NR index: '${CURRENT}' -> '${NEW_VERSION}' (env=${DEPLOYMENT_ENVIRONMENT})"
+ssm_put "${PREFIX}/previous-version" "$CURRENT"   # save the rollback target FIRST
+ssm_put "${PREFIX}/current-version" "$NEW_VERSION"
+echo "[promote] DONE. New runs resolve to '${NEW_VERSION}'; existing runs stay pinned to their AlignmentConfig."
+echo "  Rollback (instant): DEPLOYMENT_ENVIRONMENT=${DEPLOYMENT_ENVIRONMENT} scripts/reference_index_rollback.sh"

--- a/scripts/reference_index_prune.sh
+++ b/scripts/reference_index_prune.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# reference_index_prune.sh -- operational retention for OLD NT/NR index versions.
+#
+# Retention is deliberately an OPERATIONAL step, not a blind S3 lifecycle expiry:
+# deleting an index version an env still serves or might roll back to would be
+# catastrophic. This script lists the dated index versions in the reference
+# bucket, keeps the newest RETAIN_COUNT of them PLUS the pointer-referenced
+# current and previous versions (the rollback target), and prints what falls
+# outside retention. It DELETES NOTHING unless CONFIRM=1 is set -- dry-run first,
+# always. The immutable dated prefixes are the primary backup; this only reclaims
+# storage from versions well past the rollback window.
+#
+# Usage (dry-run):
+#   DEPLOYMENT_ENVIRONMENT=dev BUCKET=seqtoid-public-references-dev-<acct> \
+#     scripts/reference_index_prune.sh
+#   ... then re-run with CONFIRM=1 to actually delete.
+#
+# Env:
+#   DEPLOYMENT_ENVIRONMENT  (required)
+#   BUCKET                  (required)  the per-account reference bucket
+#   AWS_REGION              (optional, default us-west-2)
+#   RETAIN_COUNT            (optional, default 3)  newest N versions always kept
+#   CONFIRM                 (optional, "1" to actually delete; otherwise dry-run)
+
+set -euo pipefail
+
+: "${DEPLOYMENT_ENVIRONMENT:?set DEPLOYMENT_ENVIRONMENT}"
+: "${BUCKET:?set BUCKET (the per-account reference bucket)}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+RETAIN_COUNT="${RETAIN_COUNT:-3}"
+PREFIX="/seqtoid/${DEPLOYMENT_ENVIRONMENT}/reference-index"
+INDEX_ROOT="ncbi-indexes-${DEPLOYMENT_ENVIRONMENT}/"
+
+CURRENT="$(aws ssm get-parameter --region "$AWS_REGION" --name "${PREFIX}/current-version" --query 'Parameter.Value' --output text)"
+PREVIOUS="$(aws ssm get-parameter --region "$AWS_REGION" --name "${PREFIX}/previous-version" --query 'Parameter.Value' --output text)"
+
+# The dated version "directories" one level under the index root.
+mapfile -t VERSIONS < <(
+    aws s3api list-objects-v2 --region "$AWS_REGION" --bucket "$BUCKET" \
+        --prefix "$INDEX_ROOT" --delimiter / \
+        --query 'CommonPrefixes[].Prefix' --output text 2>/dev/null | tr '\t' '\n' |
+        sed "s#^${INDEX_ROOT}##; s#/\$##" | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' | sort -r
+)
+
+if (( ${#VERSIONS[@]} == 0 )); then
+    echo "[prune] no dated versions found under s3://${BUCKET}/${INDEX_ROOT}"
+    exit 0
+fi
+
+echo "[prune] env=${DEPLOYMENT_ENVIRONMENT} bucket=${BUCKET} retain_newest=${RETAIN_COUNT}"
+echo "[prune] protected pointers: current=${CURRENT} previous=${PREVIOUS}"
+
+KEEP=("${VERSIONS[@]:0:RETAIN_COUNT}" "$CURRENT" "$PREVIOUS")
+is_kept() { local v="$1"; for k in "${KEEP[@]}"; do [[ "$k" == "$v" ]] && return 0; done; return 1; }
+
+for v in "${VERSIONS[@]}"; do
+    if is_kept "$v"; then
+        echo "  KEEP   ${v}"
+    else
+        echo "  PRUNE  ${v}"
+        if [[ "${CONFIRM:-}" == "1" ]]; then
+            aws s3 rm --region "$AWS_REGION" --recursive "s3://${BUCKET}/${INDEX_ROOT}${v}/"
+            echo "         deleted s3://${BUCKET}/${INDEX_ROOT}${v}/"
+        fi
+    fi
+done
+
+[[ "${CONFIRM:-}" == "1" ]] || echo "[prune] DRY-RUN (set CONFIRM=1 to delete the PRUNE-marked versions)."

--- a/scripts/reference_index_rollback.sh
+++ b/scripts/reference_index_rollback.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# reference_index_rollback.sh -- blue/green ROLLBACK for the NT/NR sequence index.
+#
+# The sequence-DB mirror of `rake taxonomy:cutover_rollback`: flip the current
+# index-version pointer BACK to the previous version. Instant, no data moved --
+# the prior dated prefix is immutable and still present in S3, so re-pointing is
+# all it takes. Swaps current <-> previous so a rollback is itself reversible.
+#
+# Usage:
+#   DEPLOYMENT_ENVIRONMENT=dev scripts/reference_index_rollback.sh
+#   DEPLOYMENT_ENVIRONMENT=dev scripts/reference_index_rollback.sh 2024-02-06   # explicit target
+#
+# Env:
+#   DEPLOYMENT_ENVIRONMENT  (required)
+#   AWS_REGION              (optional, default us-west-2)
+
+set -euo pipefail
+
+: "${DEPLOYMENT_ENVIRONMENT:?set DEPLOYMENT_ENVIRONMENT (dev|staging|prod|sandbox)}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+PREFIX="/seqtoid/${DEPLOYMENT_ENVIRONMENT}/reference-index"
+
+ssm_get() { aws ssm get-parameter --region "$AWS_REGION" --name "$1" --query 'Parameter.Value' --output text; }
+ssm_put() { aws ssm put-parameter --region "$AWS_REGION" --name "$1" --value "$2" --type String --overwrite >/dev/null; }
+
+CURRENT="$(ssm_get "${PREFIX}/current-version")"
+PREVIOUS="$(ssm_get "${PREFIX}/previous-version")"
+
+# An explicit target overrides the stored previous pointer.
+TARGET="${1:-$PREVIOUS}"
+
+if [[ -z "$TARGET" || "$TARGET" == "-" ]]; then
+    echo "[rollback] no previous version recorded (previous-version is unset) and no explicit target given." >&2
+    echo "  Usage: DEPLOYMENT_ENVIRONMENT=${DEPLOYMENT_ENVIRONMENT} $(basename "$0") <version>" >&2
+    exit 2
+fi
+if [[ "$TARGET" == "$CURRENT" ]]; then
+    echo "[rollback] current is already '${CURRENT}'; nothing to do."
+    exit 0
+fi
+
+echo "[rollback] restoring current NT/NR index: '${CURRENT}' -> '${TARGET}' (env=${DEPLOYMENT_ENVIRONMENT})"
+ssm_put "${PREFIX}/previous-version" "$CURRENT"   # keep the just-rolled-back version as the new rollback target
+ssm_put "${PREFIX}/current-version" "$TARGET"
+echo "[rollback] DONE. New runs resolve to '${TARGET}' again."

--- a/scripts/reference_index_staleness.sh
+++ b/scripts/reference_index_staleness.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# reference_index_staleness.sh -- reference-age SLA probe for the NT/NR index.
+#
+# The sequence-DB mirror of `rake taxonomy:staleness`. Reads the current
+# index-version pointer, parses its date, computes the age in days, and:
+#   1. publishes the age as the CloudWatch metric IndexAgeDays (the
+#      reference-index staleness alarm in terraform watches this metric), and
+#   2. exits non-zero when the age exceeds the SLA, so it doubles as a CronJob
+#      probe (same behavior as the rake task's non-zero exit).
+#
+# Run it on a schedule (a Kubernetes CronJob or an EventBridge-scheduled job).
+# The alarm's treat_missing_data=breaching means: if this probe stops running,
+# the alarm fires -- an unmeasured reference age is itself an SLA failure.
+#
+# Usage:
+#   DEPLOYMENT_ENVIRONMENT=dev scripts/reference_index_staleness.sh
+#
+# Env:
+#   DEPLOYMENT_ENVIRONMENT  (required)
+#   AWS_REGION              (optional, default us-west-2)
+#   MAX_AGE_DAYS            (optional, default 400 -- ~annual NT/NR SLA)
+#   METRIC_NAMESPACE        (optional, default Seqtoid/Reference)
+#   REPORT_ONLY            (optional, "1" = publish + log but always exit 0)
+
+set -euo pipefail
+
+: "${DEPLOYMENT_ENVIRONMENT:?set DEPLOYMENT_ENVIRONMENT (dev|staging|prod|sandbox)}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+MAX_AGE_DAYS="${MAX_AGE_DAYS:-400}"
+METRIC_NAMESPACE="${METRIC_NAMESPACE:-Seqtoid/Reference}"
+PREFIX="/seqtoid/${DEPLOYMENT_ENVIRONMENT}/reference-index"
+
+VERSION="$(aws ssm get-parameter --region "$AWS_REGION" --name "${PREFIX}/current-version" --query 'Parameter.Value' --output text)"
+
+# Parse a YYYY-MM-DD date out of the version string.
+if [[ ! "$VERSION" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    echo "[staleness] cannot parse a date from current-version='${VERSION}'" >&2
+    [[ "${REPORT_ONLY:-}" == "1" ]] && exit 0
+    exit 3
+fi
+
+# Age in days (portable between GNU date and BSD/macOS date).
+if date -d "$VERSION" +%s >/dev/null 2>&1; then
+    VER_EPOCH="$(date -d "$VERSION" +%s)"          # GNU
+else
+    VER_EPOCH="$(date -j -f %Y-%m-%d "$VERSION" +%s)" # BSD/macOS
+fi
+NOW_EPOCH="$(date +%s)"
+AGE_DAYS=$(( (NOW_EPOCH - VER_EPOCH) / 86400 ))
+
+echo "[staleness] env=${DEPLOYMENT_ENVIRONMENT} current-version=${VERSION} age=${AGE_DAYS}d SLA=${MAX_AGE_DAYS}d"
+
+aws cloudwatch put-metric-data \
+    --region "$AWS_REGION" \
+    --namespace "$METRIC_NAMESPACE" \
+    --metric-name IndexAgeDays \
+    --unit Count \
+    --value "$AGE_DAYS" \
+    --dimensions "Environment=${DEPLOYMENT_ENVIRONMENT}" >/dev/null
+
+if (( AGE_DAYS > MAX_AGE_DAYS )); then
+    echo "[staleness] STALE: reference '${VERSION}' is ${AGE_DAYS} days old (SLA ${MAX_AGE_DAYS})" >&2
+    [[ "${REPORT_ONLY:-}" == "1" ]] && exit 0
+    exit 1
+fi
+echo "[staleness] OK"

--- a/terraform/reference-index-versioning-variables.tf
+++ b/terraform/reference-index-versioning-variables.tf
@@ -1,0 +1,76 @@
+# =============================================================================
+# Lever-1 GR-7 -- NT/NR sequence-DB blue/green: variables for the versioning /
+# promotion layer (the "current index version" pointer, staleness SLA, backup
+# retention). Split into its own *-variables.tf per the repo convention
+# (see cloudwatch-alarms-variables.tf). All defaults are chosen so a plan with
+# nothing set is byte-identical to before EXCEPT the three SSM pointer params,
+# which are the standalone deliverable (they seed the current serving version).
+#
+# See LEVER1-SEQUENCE-DB-BLUEGREEN-DESIGN.md and
+# LEVER1-GENERATE-ONCE-REPLICATE-DESIGN.md (phase GR-7).
+# =============================================================================
+
+variable "reference_index_current_version" {
+  description = "The dated index-generation version currently SERVING in this env (e.g. 2024-02-06). Seeds the SSM current-version pointer. Operational promote/rollback flips the SSM value out-of-band (terraform ignores value changes), mirroring how the lineage default AlignmentConfig is flipped at runtime, not in TF."
+  type        = string
+  default     = "2024-02-06"
+}
+
+variable "reference_index_previous_version" {
+  description = "The prior index-generation version retained as the fast rollback target (empty until a first promotion happens). Seeds the SSM previous-version pointer."
+  type        = string
+  default     = ""
+}
+
+variable "reference_index_major_version" {
+  description = "The index-generation major version segment of the artifact prefix (ncbi-indexes-<env>/<date>/index-generation-<major>/). Kept as a pointer so the serving prefix is fully identified without parsing paths elsewhere."
+  type        = string
+  default     = "2"
+}
+
+variable "reference_index_staleness_max_age_days" {
+  description = "Staleness SLA for the serving NT/NR sequence index, in days. The NT/NR rebuild is ~annual, so this is far larger than the quarterly lineage SLA (92). Alarm fires when the published IndexAgeDays metric exceeds this, OR when the metric is missing (the staleness probe stopped reporting)."
+  type        = number
+  default     = 400
+}
+
+variable "reference_index_staleness_metric_namespace" {
+  description = "CloudWatch namespace the staleness probe publishes IndexAgeDays into (scripts/reference_index_staleness.sh). The alarm reads the same namespace."
+  type        = string
+  default     = "Seqtoid/Reference"
+}
+
+variable "enable_reference_index_staleness_alarm" {
+  description = "Toggle the sequence-index staleness alarm. Off by default so no alarm is created until the staleness probe (CronJob / scheduled job publishing IndexAgeDays) is wired in an env; turning it on before the probe reports would immediately breach on missing data."
+  type        = bool
+  default     = false
+}
+
+# ---------------------------------------------------------------------------
+# Backup retention on the reference bucket. SCAFFOLD -- disabled by default and
+# gated on the env owning its OWN per-account reference bucket. The shared
+# reference bucket is a terraform DATA SOURCE (buckets.tf), not a TF-owned
+# resource, on purpose: it holds many TB of live taxon indexes and converting it
+# to a managed resource risks a destroy/recreate. A lifecycle configuration can
+# only be safely applied once the env has migrated to its own TF-owned bucket
+# (GR-8). Until then this stays count=0 (byte-identical plan). See the design doc
+# "Backup retention" section for why pruning old index VERSIONS is an operational
+# runbook step (scripts/reference_index_prune.sh), not a blind lifecycle expiry.
+# ---------------------------------------------------------------------------
+variable "manage_reference_index_lifecycle" {
+  description = "Opt-in to manage an S3 lifecycle configuration on the per-account reference bucket for cost-control transitions of OLD index versions. Requires PUBLIC_REFERENCES_BUCKET_NAME to be set (the env owns its own bucket). Default false = no lifecycle managed (byte-identical plan; the shared data-source bucket is never touched)."
+  type        = bool
+  default     = false
+}
+
+variable "reference_index_archive_transition_days" {
+  description = "Age (days) after which index-version objects transition to a colder storage class for cost control. Comfortably beyond the rollback window so a rollback target is never archived. Only used when manage_reference_index_lifecycle = true."
+  type        = number
+  default     = 180
+}
+
+variable "reference_index_archive_storage_class" {
+  description = "Cold storage class for aged index-version objects (GLACIER or DEEP_ARCHIVE). DEEP_ARCHIVE is cheapest but has multi-hour restore; acceptable for a superseded, non-serving index version kept only as a deep backup."
+  type        = string
+  default     = "DEEP_ARCHIVE"
+}

--- a/terraform/reference-index-versioning.tf
+++ b/terraform/reference-index-versioning.tf
@@ -58,6 +58,7 @@ locals {
 # of ownership as the lineage pointer (TF/seed owns existence, ops owns the live
 # value). tier=Standard, type=String: a short version string, not a secret.
 resource "aws_ssm_parameter" "reference_index_current_version" {
+  #checkov:skip=CKV2_AWS_34:non-secret value (a public dated index-generation version string, e.g. 2024-02-06). A SecureString/KMS param adds cost + forces --with-decryption in the promote/rollback scripts for zero confidentiality benefit; String is deliberate.
   name        = "${local.reference_index_ssm_prefix}/current-version"
   description = "Currently-serving NT/NR index-generation version (dated prefix segment). Flipped by the promote/rollback scripts; blue/green cutover pointer."
   type        = "String"
@@ -80,6 +81,7 @@ resource "aws_ssm_parameter" "reference_index_current_version" {
 # single atomic flip back. Mirrors how lineage cutover prints the previous name
 # for `taxonomy:cutover_rollback`.
 resource "aws_ssm_parameter" "reference_index_previous_version" {
+  #checkov:skip=CKV2_AWS_34:non-secret value (a public dated index-generation version string). String is deliberate; see current-version above.
   name        = "${local.reference_index_ssm_prefix}/previous-version"
   description = "Prior NT/NR index-generation version retained as the fast rollback target. Set by the promote script; consumed by the rollback script."
   type        = "String"
@@ -103,6 +105,7 @@ resource "aws_ssm_parameter" "reference_index_previous_version" {
 # without any path parsing at the consumer. Rarely changes (only on a new
 # index-generation format), so this one is TF-managed end to end (no ignore).
 resource "aws_ssm_parameter" "reference_index_major_version" {
+  #checkov:skip=CKV2_AWS_34:non-secret value (the index-generation major-version segment, e.g. 2). String is deliberate; see current-version above.
   name        = "${local.reference_index_ssm_prefix}/major-version"
   description = "index-generation major-version segment of the serving artifact prefix (index-generation-<major>)."
   type        = "String"

--- a/terraform/reference-index-versioning.tf
+++ b/terraform/reference-index-versioning.tf
@@ -1,0 +1,191 @@
+# =============================================================================
+# Lever-1 GR-7 -- NT/NR sequence-DB blue/green + backups + rollback.
+# -----------------------------------------------------------------------------
+# This is the VERSIONING / PROMOTION layer for the expensive NT/NR reference
+# index (index-generation output). It is the sequence-DB mirror of the taxon-
+# LINEAGE blue/green that already shipped in the web app:
+#
+#   lineage (shipped)                     sequence DB (this file)
+#   -----------------------------------   -----------------------------------
+#   default AlignmentConfig name          SSM /reference-index/current-version
+#     (AppConfig DB row, flipped at         (flipped out-of-band by the promote/
+#      runtime by taxonomy:cutover)          rollback scripts; TF ignores value)
+#   register a new AlignmentConfig        replicate a new dated prefix (GR-2..6)
+#   cutover = flip default (instant)      promote = flip SSM pointer (instant)
+#   cutover_rollback = flip back          rollback = flip SSM pointer back
+#   old table taxon_lineages_bak_<ts>     prior dated prefix kept immutable in S3
+#   taxonomy:staleness CronJob + SLA      IndexAgeDays metric + staleness alarm
+#
+# WHY the pointer lives in SSM (not the web AlignmentConfig row): for lineage the
+# reference is a DB table, so the pointer is naturally an AppConfig row. For the
+# NT/NR sequence DB the reference is S3 artifacts consumed by the pipeline, and
+# the promotion decision (which dated prefix is "current") is an infra concern
+# resolved before a run is dispatched. An SSM parameter is the terraform-native,
+# atomically-updatable pointer the replication/promote flow (GR-5/GR-6) reads and
+# writes, and that the web AlignmentConfig registration can mirror. Flipping one
+# parameter is atomic and instantly reversible -- exactly the lineage cutover
+# property. Historical runs stay pinned to the AlignmentConfig they ran with, so
+# a flip never rewrites a past result (same guarantee as lineage).
+#
+# WHAT STANDS ALONE (delivered, applies without the replication flow):
+#   - the three SSM pointer parameters (current / previous / major version)
+#   - the staleness alarm (off by default until the probe publishes the metric)
+#   - the promote / rollback / staleness / prune operational scripts
+# WHAT IS SCAFFOLDED (documented, disabled by default -- honest about deps):
+#   - the AUPR-gated automatic flip: promote asserts an AUPR-PASS marker that the
+#     benchmark gate (GR-6) writes; that marker producer is not built yet, so the
+#     promote script fails closed if the marker is absent (see the script).
+#   - the S3 lifecycle backup-retention config: gated on the env owning its own
+#     per-account reference bucket (GR-8); count=0 until then.
+#
+# Authored, NOT applied. No AWS job is triggered by anything here.
+# See LEVER1-SEQUENCE-DB-BLUEGREEN-DESIGN.md for the full runbook.
+# =============================================================================
+
+locals {
+  # SSM parameter namespace for the reference-index pointers, per env.
+  # Chosen to NOT begin with "aws"/"ssm" so the moto-backed test env accepts it
+  # (see the note on data.aws_ssm_parameter.idseq_batch_ami in index-generation.tf).
+  reference_index_ssm_prefix = "/seqtoid/${var.DEPLOYMENT_ENVIRONMENT}/reference-index"
+}
+
+# --- The "current index version" pointer (the blue/green flip target) --------
+# This is the sequence-DB analog of the default AlignmentConfig name. Terraform
+# OWNS the parameter's existence and SEEDS its initial value; the value itself is
+# flipped at promotion/rollback time by scripts/reference_index_{promote,rollback}.sh
+# via `aws ssm put-parameter --overwrite`. lifecycle.ignore_changes[value] keeps a
+# later `terraform apply` from reverting an operational flip -- the same division
+# of ownership as the lineage pointer (TF/seed owns existence, ops owns the live
+# value). tier=Standard, type=String: a short version string, not a secret.
+resource "aws_ssm_parameter" "reference_index_current_version" {
+  name        = "${local.reference_index_ssm_prefix}/current-version"
+  description = "Currently-serving NT/NR index-generation version (dated prefix segment). Flipped by the promote/rollback scripts; blue/green cutover pointer."
+  type        = "String"
+  value       = var.reference_index_current_version
+
+  tags = {
+    managed_by = "terraform"
+    component  = "reference-index-versioning"
+    env        = var.DEPLOYMENT_ENVIRONMENT
+  }
+
+  lifecycle {
+    # Operational promote/rollback owns the live value; do not revert it on apply.
+    ignore_changes = [value]
+  }
+}
+
+# --- The rollback target pointer (previous serving version) ------------------
+# Promote copies current -> previous BEFORE overwriting current, so rollback is a
+# single atomic flip back. Mirrors how lineage cutover prints the previous name
+# for `taxonomy:cutover_rollback`.
+resource "aws_ssm_parameter" "reference_index_previous_version" {
+  name        = "${local.reference_index_ssm_prefix}/previous-version"
+  description = "Prior NT/NR index-generation version retained as the fast rollback target. Set by the promote script; consumed by the rollback script."
+  type        = "String"
+  # An empty string is not a valid SSM value; seed a single "-" sentinel meaning
+  # "no previous version yet" (the scripts treat "-" as unset).
+  value = var.reference_index_previous_version == "" ? "-" : var.reference_index_previous_version
+
+  tags = {
+    managed_by = "terraform"
+    component  = "reference-index-versioning"
+    env        = var.DEPLOYMENT_ENVIRONMENT
+  }
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# --- The major-version segment of the artifact prefix ------------------------
+# Fully identifies the serving prefix ncbi-indexes-<env>/<version>/index-generation-<major>/
+# without any path parsing at the consumer. Rarely changes (only on a new
+# index-generation format), so this one is TF-managed end to end (no ignore).
+resource "aws_ssm_parameter" "reference_index_major_version" {
+  name        = "${local.reference_index_ssm_prefix}/major-version"
+  description = "index-generation major-version segment of the serving artifact prefix (index-generation-<major>)."
+  type        = "String"
+  value       = var.reference_index_major_version
+
+  tags = {
+    managed_by = "terraform"
+    component  = "reference-index-versioning"
+    env        = var.DEPLOYMENT_ENVIRONMENT
+  }
+}
+
+# --- Staleness alarm (the reference-age SLA) ---------------------------------
+# Mirror of the lineage `taxonomy:staleness` CronJob. The NT/NR sequence index is
+# rebuilt ~annually, so the SLA is far longer than the quarterly lineage SLA.
+#
+# CloudWatch has no native "S3 prefix age" metric, so the age is published by a
+# scheduled probe (scripts/reference_index_staleness.sh, run as a CronJob /
+# scheduled job) that reads the current-version pointer, parses its date, and
+# emits IndexAgeDays. This alarm watches that metric. treat_missing_data =
+# "breaching": if the probe stops reporting we do NOT know the age, which is
+# itself an SLA failure (same intent as the rake task's non-zero exit on an
+# unparseable/absent version). Reuses the existing pipeline-alerts SNS wiring
+# (local.pipeline_alarm_actions, defined in cloudwatch-alarms.tf).
+#
+# Off by default (see var.enable_reference_index_staleness_alarm): enabling it
+# before the probe publishes the metric would breach immediately on missing data.
+resource "aws_cloudwatch_metric_alarm" "reference_index_staleness" {
+  count = var.enable_reference_index_staleness_alarm ? 1 : 0
+
+  alarm_name        = "idseq-${var.DEPLOYMENT_ENVIRONMENT}-reference-index-staleness"
+  alarm_description = "The serving NT/NR sequence index is older than the ${var.reference_index_staleness_max_age_days}-day SLA (or the staleness probe stopped reporting) -- pipeline ${var.DEPLOYMENT_ENVIRONMENT}."
+
+  namespace   = var.reference_index_staleness_metric_namespace
+  metric_name = "IndexAgeDays"
+  dimensions  = { Environment = var.DEPLOYMENT_ENVIRONMENT }
+
+  statistic           = "Maximum"
+  period              = 86400 # once a day is plenty for an ~annual asset
+  evaluation_periods  = 1
+  threshold           = var.reference_index_staleness_max_age_days
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "breaching"
+
+  alarm_actions = local.pipeline_alarm_actions
+  ok_actions    = local.pipeline_alarm_actions
+}
+
+# --- Backup retention on the reference bucket (SCAFFOLD, gated) ---------------
+# Immutable dated prefixes are the primary backup: a superseded index version is
+# never overwritten, so rollback = re-point the SSM pointer at a prefix that is
+# still present. This lifecycle config only adds COST CONTROL: after the archive
+# window (comfortably beyond the rollback window) old index-version objects
+# transition to cold storage. It deliberately does NOT expire/delete anything --
+# deleting a version an env might still serve or roll back to would be
+# catastrophic, so pruning old VERSIONS is an explicit operational runbook step
+# (scripts/reference_index_prune.sh), never a blind lifecycle expiry.
+#
+# GATED (count=0 unless BOTH): the env has opted in AND it owns its own
+# per-account reference bucket (PUBLIC_REFERENCES_BUCKET_NAME set). The shared
+# reference bucket is a data source, not TF-owned (buckets.tf), so a lifecycle
+# config must not target it -- it belongs to whoever created it, and managing it
+# here would be a cross-owner change on a live multi-TB bucket. Activates per env
+# only after the GR-8 migration to a TF-owned per-account bucket.
+resource "aws_s3_bucket_lifecycle_configuration" "reference_index_backup_retention" {
+  count = var.manage_reference_index_lifecycle && var.PUBLIC_REFERENCES_BUCKET_NAME != "" ? 1 : 0
+
+  bucket = local.s3_bucket_public_references
+
+  rule {
+    id     = "archive-old-index-versions"
+    status = "Enabled"
+
+    filter {
+      prefix = "ncbi-indexes-"
+    }
+
+    transition {
+      days          = var.reference_index_archive_transition_days
+      storage_class = var.reference_index_archive_storage_class
+    }
+
+    # No expiration: retention/pruning of superseded index VERSIONS is an
+    # operational decision (reference_index_prune.sh), never automatic deletion.
+  }
+}


### PR DESCRIPTION
## Lever-1 GR-7: blue/green + backups + rollback for the NT/NR sequence-DB reference index

Mirrors the already-shipped taxon-lineage blue/green (register a version, flip a pointer atomically, keep the old version as a backup, roll back by flipping back, alarm on staleness) onto the expensive NT/NR `index-generation` reference. Design doc: `LEVER1-SEQUENCE-DB-BLUEGREEN-DESIGN.md` (workspace); this is phase GR-7 of the generate-once/replicate design.

Where lineage uses a DB-row pointer (the default `AlignmentConfig`), the sequence DB uses an SSM pointer, because the reference is S3 artifacts resolved by infra before a run is dispatched. This keeps the promotion layer out of `index-generation.tf` and `main.py` (both owned by other in-flight work).

### What stands alone (applies today)
- **SSM current/previous/major-version pointers** (`terraform/reference-index-versioning.tf`) -- the atomically-flippable "current index version" pointer. Terraform seeds existence + initial value; the promote/rollback scripts flip the value out-of-band (`ignore_changes = [value]`), the same seed-owns-existence / ops-owns-value split as the lineage pointer.
- **`scripts/reference_index_rollback.sh`** -- instant rollback: re-point at the retained, immutable prior dated prefix (swaps current <-> previous).
- **`scripts/reference_index_staleness.sh` + a CloudWatch alarm** -- reference-age SLA, mirroring `taxonomy:staleness`. The probe publishes an `IndexAgeDays` metric; the alarm (`treat_missing_data = breaching`) reuses the existing pipeline-alerts SNS. SLA defaults to ~annual. Alarm is off by default until the probe is scheduled.
- **`scripts/reference_index_prune.sh`** -- operational version retention (keeps newest N + current + previous; dry-run unless `CONFIRM=1`).

### What is honestly scaffolded (gated on the replication flow)
- **`scripts/reference_index_promote.sh`** -- the AUPR-gated blue/green flip. It flips fine, but **fails closed** unless an AUPR-PASS marker exists for the exact version being promoted. That marker is written by the benchmark gate (design phase GR-6), which is not built yet -- so promote blocks until GR-6 writes markers, at which point the promote path is live with no further change. `ALLOW_UNVERIFIED=1` bypasses the gate for a documented dev dry-run only.
- **S3 lifecycle backup-retention** -- authored but gated `count = 0` unless the env opts in AND owns its own per-account reference bucket. The shared reference bucket is a terraform data source (kept that way to avoid a destroy/recreate of many TB), so a lifecycle config must not target it; this activates per env only after the per-account-bucket migration (GR-8). It transitions old versions to cold storage and deliberately expires nothing (pruning is the operational script above).

### Backups
The primary backup is the immutable dated prefix -- a superseded version is never overwritten, so rollback is just a re-point at a still-present prefix. Historical runs stay pinned to their `AlignmentConfig`, so no flip ever rewrites a past result (same guarantee as lineage).

### Validation
- `terraform fmt` clean on both new `.tf` files.
- The new files validate `Success` in an isolated module with stubs for the repo externals they reference. A whole-repo `terraform validate` needs the repo's CI codegen (`make templates` + lambda packaging generating `chalice.tf.json`) + a sourced `environment.test` -- the normal CI-only validate path, unrelated to these files.
- `bash -n` clean on all four scripts.
- No `terraform apply`, no plan against a live account, no AWS job triggered.

A default plan changes only the three SSM pointer parameters; the alarm and lifecycle are both disabled by default.
