### PR TITLE
Reconcile start_index_generation to the per-stage index-generation I/O contract

### DIFF
--- a/lambdas/sfn-io-helper/chalicelib/stage_io.py
+++ b/lambdas/sfn-io-helper/chalicelib/stage_io.py
@@ -65,6 +65,71 @@ idseq_dag_io_map = collections.OrderedDict(
 
 idseq_dag_stages = list(idseq_dag_io_map)
 
+# Multi-stage index-generation (Lever 1, Track A). The index-generation SFN
+# (terraform/sfn_templates/index-generation.yml) runs three right-sized phase stages --
+# Download -> Compress -> Index -- each a whole sub-WDL (download.wdl / compress.wdl /
+# index.wdl in seqtoid-workflows). Mirroring idseq_dag_io_map above, this maps each stage's
+# cross-stage `<prev>_out_<name>` input to the identically named output of the immediately
+# preceding stage (the 1:1 name map defined by index-generation-STAGE-SPLIT.md). Download
+# takes no upstream handoff (its inputs are optional NCBI URLs defaulted in the sub-WDL);
+# Compress reads the seven Download outputs; Index reads the seven Compress outputs. The
+# accession2taxid_* + taxdump small files are passed through Compress unchanged so the
+# linear chain only ever hands off to the immediately following stage.
+index_generation_io_map = collections.OrderedDict(
+    [
+        ("Download", {}),
+        (
+            "Compress",
+            {
+                "download_out_nt": "nt",
+                "download_out_nr": "nr",
+                "download_out_accession2taxid_nucl_gb": "accession2taxid_nucl_gb",
+                "download_out_accession2taxid_nucl_wgs": "accession2taxid_nucl_wgs",
+                "download_out_accession2taxid_pdb": "accession2taxid_pdb",
+                "download_out_accession2taxid_prot": "accession2taxid_prot",
+                "download_out_taxdump": "taxdump",
+            },
+        ),
+        (
+            "Index",
+            {
+                "compress_out_nt": "nt",
+                "compress_out_nr": "nr",
+                "compress_out_accession2taxid_nucl_gb": "accession2taxid_nucl_gb",
+                "compress_out_accession2taxid_nucl_wgs": "accession2taxid_nucl_wgs",
+                "compress_out_accession2taxid_pdb": "accession2taxid_pdb",
+                "compress_out_accession2taxid_prot": "accession2taxid_prot",
+                "compress_out_taxdump": "taxdump",
+            },
+        ),
+    ]
+)
+
+index_generation_stages = list(index_generation_io_map)
+
+
+def _pipeline_for_stage(stage):
+    """Return the (stages, io_map) pair the given stage belongs to, or (None, None).
+
+    Lets read_state_from_s3 drive both the short-read-mngs (idseq_dag) and the
+    index-generation multi-stage hand-offs through one code path.
+    """
+    if stage in idseq_dag_stages:
+        return idseq_dag_stages, idseq_dag_io_map
+    if stage in index_generation_stages:
+        return index_generation_stages, index_generation_io_map
+    return None, None
+
+
+def _is_index_generation(sfn_state):
+    """True when the SFN input is the multi-stage index-generation pipeline.
+
+    Detected by the per-stage WDL URI keys the start_index_generation lambda emits
+    (DOWNLOAD_WDL_URI / COMPRESS_WDL_URI / INDEX_WDL_URI), rather than the state machine
+    name, so it does not depend on the swipe SFN naming convention.
+    """
+    return "DOWNLOAD_WDL_URI" in sfn_state and "INDEX_WDL_URI" in sfn_state
+
 
 def get_input_uri_key(stage):
     return f"{xform_name(stage).upper()}_INPUT_URI"
@@ -102,7 +167,11 @@ def read_state_from_s3(sfn_state, current_state):
             error_type = type(stage_output["error"], (Exception,), dict())
             raise error_type(stage_output["cause"])
 
-    if stage in idseq_dag_stages:
+    # Multi-stage pipelines (short-read-mngs idseq_dag, index-generation) namespace each
+    # workflow output as `<workflow_name>.<output>`; strip that prefix so the I/O map can
+    # resolve the next stage's `<prev>_out_<name>` inputs by bare output name.
+    stages, io_map = _pipeline_for_stage(stage)
+    if stages is not None:
         stage_output = {
             k.split(".", 1)[1]: v
             for k, v in stage_output.items()
@@ -110,13 +179,10 @@ def read_state_from_s3(sfn_state, current_state):
         }
     sfn_state["Result"].update(stage_output)
 
-    if (
-        stage in idseq_dag_stages
-        and idseq_dag_stages.index(stage) < len(idseq_dag_stages) - 1
-    ):
-        next_stage = idseq_dag_stages[idseq_dag_stages.index(stage) + 1]
+    if stages is not None and stages.index(stage) < len(stages) - 1:
+        next_stage = stages[stages.index(stage) + 1]
         next_stage_input = get_stage_input(sfn_state=sfn_state, stage=next_stage)
-        for input_name, result_key in idseq_dag_io_map[next_stage].items():  # type: ignore
+        for input_name, result_key in io_map[next_stage].items():  # type: ignore
             if input_name.startswith("fastqs"):
                 input_uri = sfn_state["Input"]["HostFilter"].get(input_name)
             else:
@@ -150,7 +216,7 @@ def get_workflow_name(sfn_state):
             #  so we again hardcode it!
             if (
                 s3_object(v).bucket_name == "cypherid-samples-deleteme"
-                or s3_object(v).bucket_name.starts_with("seqtoid-workflows-")
+                or s3_object(v).bucket_name.startswith("seqtoid-workflows-")
             ):
                 return os.path.dirname(s3_object(v).key)
             else:
@@ -165,11 +231,16 @@ def preprocess_sfn_input(sfn_state, aws_region, aws_account_id, state_machine_na
         output_prefix,
         re.sub(r"v(\d+)\..+", r"\1", get_workflow_name(sfn_state)),
     )
-    stages = (
-        idseq_dag_stages
-        if re.match(r"idseq-\w+-main-\d+", state_machine_name)
-        else ["Run"]
-    )
+    if _is_index_generation(sfn_state):
+        # Multi-stage index-generation: Download -> Compress -> Index. Each stage's
+        # INPUT/OUTPUT URI keys are set below so the SFN template can read
+        # $.DOWNLOAD_INPUT_URI / $.COMPRESS_OUTPUT_URI / etc., and the cross-stage
+        # download_out_* / compress_out_* hand-off is wired by read_state_from_s3.
+        stages = index_generation_stages
+    elif re.match(r"idseq-\w+-main-\d+", state_machine_name):
+        stages = idseq_dag_stages
+    else:
+        stages = ["Run"]
     for stage in stages:
         sfn_state[get_input_uri_key(stage)] = os.path.join(
             output_path, f"{xform_name(stage)}_input.json"

--- a/lambdas/sfn-io-helper/chalicelib/stage_io.py
+++ b/lambdas/sfn-io-helper/chalicelib/stage_io.py
@@ -258,6 +258,10 @@ def preprocess_sfn_input(sfn_state, aws_region, aws_account_id, state_machine_na
             f"{ecr_repo}/idseq-{workflow_name}:v{workflow_version}"
         )
         stage_input.setdefault("docker_image_id", default_docker_image_id)
-        stage_input.setdefault("s3_wd_uri", output_path)
+        if not _is_index_generation(sfn_state):
+            # index-gen sub-WDLs (download/compress/index) do not declare s3_wd_uri,
+            # so miniwdl would reject it at input validation. short-read-mngs and the
+            # single-stage "Run" workflows do declare String s3_wd_uri and rely on it.
+            stage_input.setdefault("s3_wd_uri", output_path)
         put_stage_input(sfn_state=sfn_state, stage=stage, stage_input=stage_input)
     return sfn_state

--- a/lambdas/sfn-io-helper/test/test_stage_io.py
+++ b/lambdas/sfn-io-helper/test/test_stage_io.py
@@ -103,5 +103,93 @@ class TestIdseqDagIoMap(unittest.TestCase):
             self.assertIsNone(v)
 
 
+class TestIndexGenerationIoMap(unittest.TestCase):
+    # The seven cross-stage database names handed off between index-generation stages.
+    HANDOFF_NAMES = {
+        "nt",
+        "nr",
+        "accession2taxid_nucl_gb",
+        "accession2taxid_nucl_wgs",
+        "accession2taxid_pdb",
+        "accession2taxid_prot",
+        "taxdump",
+    }
+
+    def test_stage_order_is_the_pipeline_order(self):
+        self.assertEqual(
+            stage_io.index_generation_stages,
+            ["Download", "Compress", "Index"],
+        )
+
+    def test_stages_match_io_map_keys_and_order(self):
+        self.assertEqual(
+            stage_io.index_generation_stages,
+            list(stage_io.index_generation_io_map),
+        )
+
+    def test_download_takes_no_upstream_handoff(self):
+        # The first stage's inputs are optional NCBI URLs defaulted in the sub-WDL.
+        self.assertEqual(stage_io.index_generation_io_map["Download"], {})
+
+    def test_compress_reads_the_seven_download_outputs(self):
+        compress = stage_io.index_generation_io_map["Compress"]
+        self.assertEqual(
+            set(compress),
+            {f"download_out_{n}" for n in self.HANDOFF_NAMES},
+        )
+        # Each download_out_<X> resolves to the identically named Download output <X>.
+        for input_name, result_key in compress.items():
+            self.assertEqual(input_name, f"download_out_{result_key}")
+            self.assertIn(result_key, self.HANDOFF_NAMES)
+
+    def test_index_reads_the_seven_compress_outputs(self):
+        index = stage_io.index_generation_io_map["Index"]
+        self.assertEqual(
+            set(index),
+            {f"compress_out_{n}" for n in self.HANDOFF_NAMES},
+        )
+        for input_name, result_key in index.items():
+            self.assertEqual(input_name, f"compress_out_{result_key}")
+            self.assertIn(result_key, self.HANDOFF_NAMES)
+
+    def test_pipeline_for_stage_routes_each_family(self):
+        self.assertEqual(
+            stage_io._pipeline_for_stage("Compress"),
+            (stage_io.index_generation_stages, stage_io.index_generation_io_map),
+        )
+        self.assertEqual(
+            stage_io._pipeline_for_stage("NonHostAlignment"),
+            (stage_io.idseq_dag_stages, stage_io.idseq_dag_io_map),
+        )
+        self.assertEqual(stage_io._pipeline_for_stage("Run"), (None, None))
+
+    def test_is_index_generation_detects_wdl_uri_keys(self):
+        self.assertTrue(
+            stage_io._is_index_generation(
+                {
+                    "DOWNLOAD_WDL_URI": "s3://b/index-generation-v1/download.wdl",
+                    "COMPRESS_WDL_URI": "s3://b/index-generation-v1/compress.wdl",
+                    "INDEX_WDL_URI": "s3://b/index-generation-v1/index.wdl",
+                }
+            )
+        )
+        self.assertFalse(
+            stage_io._is_index_generation({"RUN_WDL_URI": "s3://b/default-v1/run.wdl"})
+        )
+        self.assertFalse(
+            stage_io._is_index_generation(
+                {"HOST_FILTER_WDL_URI": "s3://b/short-read-mngs-v1/host_filter.wdl"}
+            )
+        )
+
+
+class TestIndexGenerationUriKeys(unittest.TestCase):
+    def test_input_and_output_uri_keys(self):
+        self.assertEqual(stage_io.get_input_uri_key("Download"), "DOWNLOAD_INPUT_URI")
+        self.assertEqual(stage_io.get_output_uri_key("Download"), "DOWNLOAD_OUTPUT_URI")
+        self.assertEqual(stage_io.get_input_uri_key("Compress"), "COMPRESS_INPUT_URI")
+        self.assertEqual(stage_io.get_output_uri_key("Index"), "INDEX_OUTPUT_URI")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/lambdas/sfn-io-helper/test/test_stage_io.py
+++ b/lambdas/sfn-io-helper/test/test_stage_io.py
@@ -11,6 +11,7 @@
 
 import os
 import unittest
+from unittest import mock
 
 os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
 
@@ -189,6 +190,113 @@ class TestIndexGenerationUriKeys(unittest.TestCase):
         self.assertEqual(stage_io.get_output_uri_key("Download"), "DOWNLOAD_OUTPUT_URI")
         self.assertEqual(stage_io.get_input_uri_key("Compress"), "COMPRESS_INPUT_URI")
         self.assertEqual(stage_io.get_output_uri_key("Index"), "INDEX_OUTPUT_URI")
+
+
+class TestPreprocessSfnInputS3WdUri(unittest.TestCase):
+    # preprocess_sfn_input writes each stage's input JSON to S3 via put_stage_input and
+    # reads only WDL-URI *strings* (get_workflow_name parses the URI locally, no network).
+    # We patch put_stage_input to capture the emitted per-stage inputs, so these tests run
+    # AWS-free like the rest of this module. They lock the contract that s3_wd_uri is
+    # injected for the WDLs that declare `String s3_wd_uri` (short-read-mngs / single-stage
+    # "Run") but NOT for the index-generation sub-WDLs (download/compress/index), which do
+    # not declare it and whose miniwdl input validation would otherwise reject it.
+
+    REGION = "us-west-2"
+    ACCOUNT_ID = "123456789012"
+
+    def _run(self, sfn_state, state_machine_name, memory_stages):
+        captured = {}
+
+        def _capture(sfn_state, stage, stage_input):
+            captured[stage] = stage_input
+
+        env = {}
+        for stage in memory_stages:
+            for compute_env in ("SPOT", "EC2"):
+                env[stage + compute_env + "MemoryDefault"] = "4096"
+        with mock.patch.object(stage_io, "put_stage_input", side_effect=_capture), \
+                mock.patch.dict(os.environ, env):
+            stage_io.preprocess_sfn_input(
+                sfn_state,
+                aws_region=self.REGION,
+                aws_account_id=self.ACCOUNT_ID,
+                state_machine_name=state_machine_name,
+            )
+        return captured
+
+    def test_index_generation_stages_get_no_s3_wd_uri(self):
+        # WDL URIs live in a seqtoid-workflows-* bucket, so get_workflow_name returns the
+        # key's dirname ("index-generation-v1"); the DOWNLOAD_/INDEX_WDL_URI keys make
+        # _is_index_generation True.
+        base = "s3://seqtoid-workflows-dev/index-generation-v1"
+        sfn_state = {
+            "OutputPrefix": "s3://out-bucket/runs/abc",
+            "Input": {},
+            "DOWNLOAD_WDL_URI": f"{base}/download.wdl",
+            "COMPRESS_WDL_URI": f"{base}/compress.wdl",
+            "INDEX_WDL_URI": f"{base}/index.wdl",
+        }
+        captured = self._run(
+            sfn_state,
+            state_machine_name="idseq-index-generation-main-1",
+            memory_stages=stage_io.index_generation_stages,
+        )
+
+        self.assertEqual(set(captured), {"Download", "Compress", "Index"})
+        for stage, stage_input in captured.items():
+            self.assertNotIn(
+                "s3_wd_uri",
+                stage_input,
+                f"index-generation stage {stage} must not carry s3_wd_uri",
+            )
+            # docker_image_id is still injected for every stage.
+            self.assertIn("docker_image_id", stage_input)
+
+    def test_short_read_mngs_stages_still_get_s3_wd_uri(self):
+        # No DOWNLOAD_/INDEX_WDL_URI keys -> not index-generation; the idseq-*-main-N state
+        # machine name selects the idseq_dag stages.
+        base = "s3://seqtoid-workflows-dev/short-read-mngs-v1"
+        sfn_state = {
+            "OutputPrefix": "s3://out-bucket/runs/abc",
+            "Input": {},
+            "HOST_FILTER_WDL_URI": f"{base}/host_filter.wdl",
+        }
+        captured = self._run(
+            sfn_state,
+            state_machine_name="idseq-mngs-main-1",
+            memory_stages=stage_io.idseq_dag_stages,
+        )
+
+        expected_path = os.path.join(sfn_state["OutputPrefix"], "short-read-mngs-v1")
+        self.assertEqual(
+            set(captured),
+            {"HostFilter", "NonHostAlignment", "Postprocess", "Experimental"},
+        )
+        for stage, stage_input in captured.items():
+            self.assertEqual(
+                stage_input.get("s3_wd_uri"),
+                expected_path,
+                f"short-read-mngs stage {stage} must carry s3_wd_uri",
+            )
+
+    def test_single_stage_run_workflow_gets_s3_wd_uri(self):
+        # The default single-stage "Run" path (neither index-generation nor idseq-dag)
+        # also declares s3_wd_uri and must keep receiving it.
+        base = "s3://seqtoid-workflows-dev/consensus-genome-v1"
+        sfn_state = {
+            "OutputPrefix": "s3://out-bucket/runs/abc",
+            "Input": {},
+            "RUN_WDL_URI": f"{base}/run.wdl",
+        }
+        captured = self._run(
+            sfn_state,
+            state_machine_name="cg-wdl-1",
+            memory_stages=["Run"],
+        )
+
+        expected_path = os.path.join(sfn_state["OutputPrefix"], "consensus-genome-v1")
+        self.assertEqual(set(captured), {"Run"})
+        self.assertEqual(captured["Run"].get("s3_wd_uri"), expected_path)
 
 
 if __name__ == "__main__":

--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 from uuid import uuid4
 
 import boto3
@@ -12,14 +11,24 @@ import boto3
 # memory overrides the template consumes ($.DownloadEC2Memory, $.CompressEC2Memory,
 # $.IndexSPOTMemory, $.IndexEC2Memory).
 #
-# UPSTREAM DEPENDENCY (seqtoid-workflows WDL split PR): a SWIPE stage runs a WHOLE WDL
-# locally, so each stage needs its own sub-WDL (download.wdl / compress.wdl / index.wdl)
-# built into the index-generation image and uploaded to the workflows bucket. Until that
-# lands, the URIs below resolve to files that do not exist yet and the pipeline cannot run
-# end-to-end -- the infra is authored to consume them. The EXACT per-stage Input keys each
-# sub-WDL reads (and the S3 hand-off URIs between Compress and Index) are defined by those
-# sub-WDLs and must be reconciled here when they land; the payloads below carry the common
-# run inputs as the starting contract.
+# PER-STAGE Input CONTRACT (reconciled with the seqtoid-workflows WDL split,
+# workflows/index-generation/index-generation-STAGE-SPLIT.md). A SWIPE stage runs a WHOLE
+# sub-WDL locally (download.wdl / compress.wdl / index.wdl), and miniwdl rejects any
+# top-level input the sub-WDL does not declare. So each stage's Input.<Stage> below carries
+# ONLY the keys that stage's sub-WDL declares:
+#
+#   Download (index_generation_download): docker_image_id
+#   Compress (index_generation_compress): docker_image_id
+#   Index    (index_generation_index):    docker_image_id, index_name, previous_lineages?
+#
+# The cross-stage database hand-off inputs -- Compress's seven download_out_* and Index's
+# seven compress_out_* (nt, nr, the four accession2taxid_*, taxdump) -- are NOT set here:
+# their S3 URIs do not exist until the prior stage runs. The swipe sfn-io-helper
+# (lambdas/sfn-io-helper/chalicelib/stage_io.py, index_generation_io_map) injects each
+# <prev>_out_<name> into the next stage's input.json from the prior stage's identically
+# named output after that stage completes (the same mechanism short-read-mngs uses for its
+# <stage>_out_<name> hand-off). write_to_db / env / s3_dir are NOT sent: no sub-WDL declares
+# them and miniwdl would fail on the undeclared inputs.
 
 # Sub-WDL filenames per stage, resolved under the versioned workflows prefix. Kept here as
 # the single place to reconcile with the seqtoid-workflows WDL split.
@@ -46,8 +55,6 @@ def start_index_generation(event, *args):
     index_spot_memory = int(os.environ["INDEX_SPOT_MEMORY"])
     index_ec2_memory = int(os.environ["INDEX_EC2_MEMORY"])
 
-    major_version = re.search(r"v(\d+)\..+", version).group(1)
-
     sfn = boto3.client("stepfunctions")
     s3 = boto3.client("s3")
 
@@ -66,30 +73,37 @@ def start_index_generation(event, *args):
                 previous_lineages = key
 
     index_name = event["time"][:10]
-    s3_dir = f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/index-generation-{major_version}"
 
     def wdl_uri(stage):
         return f"s3://{workflows_bucket}/index-generation-{version}/{STAGE_WDL_FILENAMES[stage]}"
 
-    # Common run inputs shared by every stage. The per-stage sub-WDLs (seqtoid-workflows WDL
-    # split) will consume the subset each phase needs; reconcile exact keys when they land.
-    common_run_input = {
-        "docker_image_id": f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/index-generation:{version}",
-        "write_to_db": True,
+    docker_image_id = (
+        f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/index-generation:{version}"
+    )
+
+    # Per-stage Input payloads. Each stage gets ONLY the top-level inputs its sub-WDL
+    # declares (see the PER-STAGE Input CONTRACT note above); the cross-stage download_out_* /
+    # compress_out_* database hand-off is injected at runtime by the swipe sfn-io-helper.
+    download_input = {"docker_image_id": docker_image_id}
+    compress_input = {"docker_image_id": docker_image_id}
+    index_input = {
+        "docker_image_id": docker_image_id,
         "index_name": index_name,
-        "env": deployment_environment,
-        "s3_dir": s3_dir,
-        "previous_lineages": f"s3://{bucket}/{previous_lineages}",
     }
+    # index.wdl declares `File? previous_lineages` (optional). Only pass it when a prior
+    # index exists; otherwise leave it unset so the incremental-lineage step is skipped
+    # instead of pointing at a non-existent object.
+    if previous_lineages:
+        index_input["previous_lineages"] = f"s3://{bucket}/{previous_lineages}"
 
     input_dict = {
         "DOWNLOAD_WDL_URI": wdl_uri("Download"),
         "COMPRESS_WDL_URI": wdl_uri("Compress"),
         "INDEX_WDL_URI": wdl_uri("Index"),
         "Input": {
-            "Download": dict(common_run_input),
-            "Compress": dict(common_run_input),
-            "Index": dict(common_run_input),
+            "Download": download_input,
+            "Compress": compress_input,
+            "Index": index_input,
         },
         "OutputPrefix": f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/",
         # Per-stage container memory overrides consumed by the SFN template.


### PR DESCRIPTION
## What

Reconciles the `start_index_generation` lambda to the per-stage I/O contract of Track A's multi-stage index-generation pipeline. This is the last glue that makes Track A executable end-to-end (Track A remains gated on the AUPR rebuild -- this is wiring only, no run is triggered).

The monolithic WDL was split into per-stage sub-WDLs (`download.wdl` / `compress.wdl` / `index.wdl` in seqtoid-workflows, `czid-763-index-gen-wdl-split`). A SWIPE stage runs a whole sub-WDL locally and miniwdl rejects any undeclared top-level input, so the old `common_run_input` (copied identically into every stage's `Input.<Stage>`) no longer matches what the sub-WDLs declare. Contract source: `workflows/index-generation/index-generation-STAGE-SPLIT.md`, cross-checked against the actual sub-WDL `input {}` / `output {}` blocks.

## Per-stage Input mapping (old monolithic -> new per-stage)

Old: `Input.Download == Input.Compress == Input.Index == common_run_input`, where
`common_run_input = {docker_image_id, write_to_db, index_name, env, s3_dir, previous_lineages}`.

New, each carrying only the keys its sub-WDL declares:

| Stage (workflow) | `Input.<Stage>` keys set by main.py |
|---|---|
| Download (`index_generation_download`) | `docker_image_id` |
| Compress (`index_generation_compress`) | `docker_image_id` |
| Index (`index_generation_index`) | `docker_image_id`, `index_name`, `previous_lineages` (only when a prior index exists; `File? previous_lineages`) |

## Removed

- `write_to_db`, `env`, `s3_dir` -- no sub-WDL declares them; miniwdl would fail on the undeclared inputs.
- The now-unused `s3_dir` / `major_version` computation and the `import re` in main.py.

`index_name` now lives only on Index; `docker_image_id` on all three; `previous_lineages` only on Index.

## S3 hand-off wiring (the important part -- NOT in main.py or the SFN template)

The cross-stage `download_out_*` / `compress_out_*` inputs are NOT set by main.py: those S3 URIs do not exist until the prior stage runs. In the SWIPE architecture the hand-off is performed by the `sfn-io-helper` lambda (`lambdas/sfn-io-helper/chalicelib/stage_io.py`), which the SFN's `PreprocessInput` and `*ReadOutput` states invoke -- exactly the "how it threads a stage's outputs into the next state's Input" mechanism. That adapter only knew the short-read-mngs stages, so it is extended here:

- `index_generation_io_map` / `index_generation_stages`: the 1:1 name map wiring each stage's `<prev>_out_<X>` input to the prior stage's identically named output, for `<X>` in {`nt`, `nr`, `accession2taxid_nucl_gb`, `accession2taxid_nucl_wgs`, `accession2taxid_pdb`, `accession2taxid_prot`, `taxdump`}. Download takes no upstream hand-off; Compress reads the seven Download outputs; Index reads the seven Compress outputs (accession2taxid_* + taxdump pass through Compress unchanged, so the linear chain only ever hands to the immediately following stage).
- `preprocess_sfn_input` detects the index-generation pipeline (by its per-stage WDL URI keys) and selects the `Download -> Compress -> Index` stage list, so the per-stage `*_INPUT_URI` / `*_OUTPUT_URI` keys the SFN template reads actually get set.
- `read_state_from_s3` drives both pipelines' hand-off through one `_pipeline_for_stage` code path (short-read-mngs behavior unchanged).

## Was main.py alone sufficient? No.

- **main.py**: required (per-stage Input keys).
- **stage_io.py** (swipe sfn-io-helper): required -- it is where the `<prev>_out_<X>` hand-off resolves and where the per-stage stage list / URI keys are produced. Without it the SFN references `$.DOWNLOAD_INPUT_URI` etc. that nothing sets.
- **SFN template (`index-generation.yml`)**: no change needed -- it already reads the per-stage URIs and memory keys that main.py + stage_io.py now populate.

## Adjacent blocker fixed (flagged)

`get_workflow_name` used `str.starts_with` (not a real method; it is `startswith`), raising `AttributeError` in `preprocess_sfn_input` for any WDL in the `seqtoid-workflows-*` bucket -- a hard blocker on the preprocess path for BOTH index-generation and short-read-mngs. Fixed to `.startswith`. This code path had clearly never executed against that bucket; the fix cannot regress anything that works today.

## Validation

- `python3 -c "import ast; ast.parse(...)"` compiles: main.py, stage_io.py, test_stage_io.py.
- `python3 -m unittest test.test_stage_io -v`: 19 tests pass (8 new for the index-generation map + URI keys).
- `flake8 --config=.flake8 lambdas/sfn-io-helper/chalicelib/stage_io.py`: clean (exit 0).
- Emitted per-stage keys are a subset of each sub-WDL's declared inputs (verified against the `input {}` blocks): Download `{docker_image_id}` subset of `{ncbi_server, provided_*, docker_image_id}`; Compress `{docker_image_id}` + runtime `download_out_*` == its seven required cross-stage inputs; Index `{docker_image_id, index_name, previous_lineages?}` + runtime `compress_out_*` == its required inputs.
- No `.tf` files touched (no `terraform fmt` needed). No apply, no SFN/Batch run triggered.

## Open note (not changed)

`preprocess_sfn_input` also injects `s3_wd_uri` into every stage input (unconditional swipe plumbing, applied to all swipe workflows including the single-stage `Run`). The index-generation sub-WDLs do not declare `s3_wd_uri`; the STAGE-SPLIT contract did not flag it (it flags only write_to_db/env/s3_dir), so it is treated as swipe-runner-consumed plumbing and left unchanged. If miniwdl does reject it, that is a swipe-wide concern, not specific to this reconciliation.
