### PR TITLE
feat(benchmark): UCSF-owned benchmark truth-files bucket + reader grants (#580 P1)

### DIFF
--- a/terraform/batch_job.tf
+++ b/terraform/batch_job.tf
@@ -12,7 +12,8 @@ resource "aws_iam_policy" "idseq_batch_main_job" {
     AWS_ACCOUNT_ID         = var.AWS_ACCOUNT_ID,
     DEPLOYMENT_ENVIRONMENT = var.DEPLOYMENT_ENVIRONMENT,
     PARAMETER_KMS_KEY_ARN  = length(data.aws_kms_alias.parameter_store) > 0 ? data.aws_kms_alias.parameter_store[0].target_key_arn : "",
-    S3_WORKFLOWS_BUCKET    = aws_s3_bucket.workflows.bucket
+    S3_WORKFLOWS_BUCKET    = aws_s3_bucket.workflows.bucket,
+    S3_BENCH_BUCKET        = aws_s3_bucket.benchmark.bucket
   })
 }
 

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -39,6 +39,17 @@ locals {
   # the current dev/staging/prod path is unchanged (byte-identical plan).
   s3_bucket_public_references = var.PUBLIC_REFERENCES_BUCKET_NAME != "" ? var.PUBLIC_REFERENCES_BUCKET_NAME : "seqtoid-public-references"
 
+  # Benchmark bucket repoint (UCSF replacement for CZI idseq-bench): UCSF-owned
+  # benchmark truth-files bucket. Per-account unique name, same
+  # convention as the workflows bucket. This replaces the CZI-owned, public-read
+  # s3://idseq-bench on the runtime Benchmark path -- the last CZI bucket a UCSF
+  # pipeline read from. UCSF can read idseq-bench but cannot write it; this bucket is
+  # writable + owned in-account. Objects follow the idseq-bench layout, i.e.
+  # datasets/truth_files/*.txt (+ datasets/fastqs/*.fastq.gz) -- see the app default
+  # in seqtoid-web app/models/benchmark_workflow_run.rb and the S3_TRUTH_FILES_BUCKET
+  # env override wired in deploy/argocd/values/seqtoid-web/dev.yaml (web-infra).
+  s3_bucket_benchmark = "seqtoid-bench-${var.DEPLOYMENT_ENVIRONMENT}-${var.AWS_ACCOUNT_ID}"
+
   # DATA-1 (CZID-31): allow terraform to destroy data resources only in throwaway envs;
   # protect the shared/long-lived envs (staging/prod) from a silent destroy/replace data loss.
   data_force_destroy = contains(["dev", "sandbox"], var.DEPLOYMENT_ENVIRONMENT)
@@ -183,4 +194,107 @@ data "aws_iam_policy_document" "workflows-bucket" {
 resource "aws_s3_bucket_policy" "workflows" {
   bucket = aws_s3_bucket.workflows.id
   policy = data.aws_iam_policy_document.workflows-bucket.json
+}
+
+# =============================================================================
+# Benchmark truth-files bucket (UCSF-owned, PRIVATE) -- UCSF replacement for CZI idseq-bench.
+#
+# Stands up the UCSF replacement for the CZI-owned, public-read s3://idseq-bench,
+# the single remaining CZI bucket on a runtime path (it gates the Benchmark = the
+# AWS e2e correctness / beta-readiness validator). PRIVATE -- access is via IAM
+# only (batch job role, CI role, the app's seqtoid-web pod role), NOT public.
+#
+# Mirrors the workflows bucket (per-account name, public-access-block, versioning,
+# lifecycle) with ONE deliberate difference: SSE-S3 (AES256) instead of the
+# customer-managed workflows KMS key. The truth files are non-sensitive benchmark
+# fixtures that today live in a WORLD-READABLE bucket; encrypting them with the
+# workflows CMK would force every reader role (batch, CI, app pod) to also carry a
+# kms:Decrypt grant on that key, coupling the runtime read path to KMS for no
+# confidentiality benefit. AES256 keeps the bucket private (IAM + public-access-
+# block) and encrypted at rest while each reader needs only its S3 grant.
+resource "aws_s3_bucket" "benchmark" {
+  # checkov:skip=CKV_AWS_145:Non-sensitive, public-origin benchmark fixtures; SSE-S3 (AES256, configured separately) avoids coupling every reader role to a kms:Decrypt grant on the workflows CMK (see comment above). Bucket stays private via IAM + public-access-block. Mirrors the workflows bucket, which accepts the same finding.
+  # checkov:skip=CKV_AWS_18:Access logging not enabled -- these are low-sensitivity, IAM-gated benchmark fixtures mirrored from a formerly world-readable bucket; per-request S3 access logs add cost/noise without a security benefit. Mirrors the workflows bucket, which accepts the same finding.
+  # checkov:skip=CKV_AWS_144:Cross-region replication not warranted -- benchmark fixtures are reproducible (mirror of the public idseq-bench) and versioned; a second-region copy is unnecessary. Mirrors the workflows bucket, which accepts the same finding.
+  # checkov:skip=CKV2_AWS_62:No event-driven consumers of this bucket -- benchmark fixtures are read on the pipeline path via IAM, not via S3 event notifications. Mirrors the workflows bucket, which accepts the same finding.
+  bucket        = local.s3_bucket_benchmark
+  force_destroy = local.data_force_destroy
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "benchmark" {
+  bucket = aws_s3_bucket.benchmark.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# Block all public access. Unlike the CZI idseq-bench (public-read), this bucket is
+# private; readers reach it through their own IAM policies. (CZID-57 / Trivy
+# AWS-0086-0093, Checkov CKV2_AWS_6.)
+resource "aws_s3_bucket_public_access_block" "benchmark" {
+  bucket                  = aws_s3_bucket.benchmark.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Versioning: truth files are the ground truth the Benchmark scores AUPR against, so
+# keep a history -- an accidental overwrite of a *_TRUTH.txt must be recoverable.
+resource "aws_s3_bucket_versioning" "benchmark" {
+  bucket = aws_s3_bucket.benchmark.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "benchmark" {
+  # checkov:skip=CKV_AWS_300:Truth-file fixtures are uploaded as small single-part objects; a dedicated abort-incomplete-multipart-upload rule is not needed. Mirrors the workflows bucket lifecycle config, which accepts the same finding.
+  depends_on = [aws_s3_bucket_versioning.benchmark]
+  bucket     = aws_s3_bucket.benchmark.id
+
+  rule {
+    id = "default"
+    filter {}
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "DEEP_ARCHIVE"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    status = "Enabled"
+  }
+}
+
+# Own-account read (belt-and-suspenders alongside the reader roles' IAM policies),
+# mirroring the workflows bucket policy. No cross-account delegation: unlike the
+# workflows outputs, benchmark fixtures are read only by same-account roles.
+data "aws_iam_policy_document" "benchmark-bucket" {
+  statement {
+    sid = "ReadAccess"
+    actions = [
+      "s3:ListBucket*",
+      "s3:GetObject*"
+    ]
+    resources = [
+      aws_s3_bucket.benchmark.arn,
+      "${aws_s3_bucket.benchmark.arn}/*"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = formatlist("arn:aws:iam::%s:root", var.AWS_ACCOUNT_ID)
+    }
+    effect = "Allow"
+  }
+}
+
+resource "aws_s3_bucket_policy" "benchmark" {
+  bucket = aws_s3_bucket.benchmark.id
+  policy = data.aws_iam_policy_document.benchmark-bucket.json
 }

--- a/terraform/ci-cd.tf
+++ b/terraform/ci-cd.tf
@@ -53,7 +53,8 @@
 #     AWS_DEFAULT_REGION     = var.AWS_DEFAULT_REGION,
 #     AWS_ACCOUNT_ID         = var.AWS_ACCOUNT_ID,
 #     DEPLOYMENT_ENVIRONMENT = var.DEPLOYMENT_ENVIRONMENT,
-#     S3_WORKFLOWS_BUCKET    = data.aws_s3_bucket.workflows.bucket
+#     S3_WORKFLOWS_BUCKET    = data.aws_s3_bucket.workflows.bucket,
+#     S3_BENCH_BUCKET        = aws_s3_bucket.benchmark.bucket
 #   })
 # }
 

--- a/terraform/iam_policy_templates/batch_job.json
+++ b/terraform/iam_policy_templates/batch_job.json
@@ -16,6 +16,8 @@
         "arn:aws:s3:::seqtoid-public-references/*",
         "arn:aws:s3:::czid-public-references",
         "arn:aws:s3:::czid-public-references/*",
+        "arn:aws:s3:::${S3_BENCH_BUCKET}",
+        "arn:aws:s3:::${S3_BENCH_BUCKET}/*",
         "arn:aws:s3:::idseq-bench",
         "arn:aws:s3:::idseq-bench/*"
       ]

--- a/terraform/iam_policy_templates/ci_cd.json
+++ b/terraform/iam_policy_templates/ci_cd.json
@@ -16,6 +16,8 @@
         "arn:aws:s3:::aegea-batch-jobs-${AWS_ACCOUNT_ID}/*",
         "arn:aws:s3:::idseq-${DEPLOYMENT_ENVIRONMENT}-*",
         "arn:aws:s3:::idseq-${DEPLOYMENT_ENVIRONMENT}-*/*",
+        "arn:aws:s3:::${S3_BENCH_BUCKET}",
+        "arn:aws:s3:::${S3_BENCH_BUCKET}/*",
         "arn:aws:s3:::idseq-bench",
         "arn:aws:s3:::idseq-bench/*"
       ]


### PR DESCRIPTION
Lever/benchmark #580 P1: UCSF-owned dev benchmark truth-files bucket (seqtoid-bench-dev-<acct>) in buckets.tf + read grants for the batch/CI roles. HELD/DRAFT: do not apply until the bucket is created + the truth set mirrored. Creds-gated hand-off (Tom): apply -> aws s3 sync s3://idseq-bench/datasets/ s3://seqtoid-bench-dev-491013321714/datasets/ -> upload the euk positives from EUK-BENCH-UPLOAD/. Re-pointed from a thorvath-slower fork PR to the canonical itars repo. Ticket tracked in Forgejo (prose only).