### PR TITLE
fix(sfn-io-helper): str.starts_with typo + harden failed-stage error path (CZID-775)

### DIFF
--- a/lambdas/sfn-io-helper/chalicelib/stage_io.py
+++ b/lambdas/sfn-io-helper/chalicelib/stage_io.py
@@ -99,8 +99,11 @@ def read_state_from_s3(sfn_state, current_state):
     # If the stage succeeded, don't throw an error
     if not sfn_state.get("BatchJobDetails", {}).get(stage):
         if batch_job_error and next(iter(batch_job_error)).startswith(stage):
-            error_type = type(stage_output["error"], (Exception,), dict())
-            raise error_type(stage_output["cause"])
+            # A failed stage does not always leave an {error, cause} shaped output.json
+            # (e.g. the container dies before writing one). Degrade gracefully so the real
+            # Batch failure surfaces instead of masking it with a KeyError.
+            error_type = type(stage_output.get("error", "StageFailed"), (Exception,), dict())
+            raise error_type(stage_output.get("cause", stage_output.get("message", f"{stage} stage failed; see Batch job logs")))
 
     if stage in idseq_dag_stages:
         stage_output = {
@@ -150,7 +153,7 @@ def get_workflow_name(sfn_state):
             #  so we again hardcode it!
             if (
                 s3_object(v).bucket_name == "cypherid-samples-deleteme"
-                or s3_object(v).bucket_name.starts_with("seqtoid-workflows-")
+                or s3_object(v).bucket_name.startswith("seqtoid-workflows-")
             ):
                 return os.path.dirname(s3_object(v).key)
             else:


### PR DESCRIPTION
Fixes two latent bugs in the chalice sfn-io-helper `stage_io.py`, found while validating the multi-stage index-generation handoff.

- **`str.starts_with` typo** (`get_workflow_name`): Python `str` has no `starts_with`; it is `startswith`. This raises `AttributeError` whenever a `_WDL_URI` resolves to a `seqtoid-workflows-*` bucket.
- **Unguarded failed-stage error read** (`read_state_from_s3`): when a stage fails, the code read `stage_output['error']`/`['cause']` unconditionally. A container that dies before writing an `{error, cause}` output.json (e.g. an exec-format crash) then raises `KeyError('error')`, masking the real Batch failure. Now degrades gracefully to a generic message so the actual failure surfaces.

Surgical fixes only; the chalice app's Sentry / CE-autoscaling / sfn-archiving features are untouched. All 11 existing io-helper unit tests pass.

Tracking: platform-overhaul CZID-775.