### PR TITLE
fix(index-generation): start lambda emits the deployed io-helper contract (CZID-774)

### DIFF
--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -1,32 +1,53 @@
 import json
 import os
-import re
 from uuid import uuid4
 
 import boto3
 
 # Multi-stage index-generation (Lever 1, Track A). The SFN state machine
-# (sfn_templates/index-generation.yml) now runs three right-sized phase stages -- Download,
-# Compress, Index -- instead of one monolithic RunEC2 job. This lambda builds the per-stage
-# SFN input: a per-stage WDL URI, a per-stage Input payload, and the per-stage container
-# memory overrides the template consumes ($.DownloadEC2Memory, $.CompressEC2Memory,
-# $.IndexSPOTMemory, $.IndexEC2Memory).
+# (sfn_templates/index-generation.yml) runs three right-sized phase stages -- Download,
+# Compress, Index -- instead of one monolithic RunEC2 job. This lambda builds the SFN input
+# in the exact shape the deployed SWIPE io-helper (module.swipe sfn_io_helper) consumes:
 #
-# UPSTREAM DEPENDENCY (seqtoid-workflows WDL split PR): a SWIPE stage runs a WHOLE WDL
-# locally, so each stage needs its own sub-WDL (download.wdl / compress.wdl / index.wdl)
-# built into the index-generation image and uploaded to the workflows bucket. Until that
-# lands, the URIs below resolve to files that do not exist yet and the pipeline cannot run
-# end-to-end -- the infra is authored to consume them. The EXACT per-stage Input keys each
-# sub-WDL reads (and the S3 hand-off URIs between Compress and Index) are defined by those
-# sub-WDLs and must be reconciled here when they land; the payloads below carry the common
-# run inputs as the starting contract.
+#   * one per-stage WDL URI (DOWNLOAD_WDL_URI / COMPRESS_WDL_URI / INDEX_WDL_URI),
+#   * a per-stage `Input.<Stage>` payload carrying ONLY that sub-WDL's declared workflow
+#     inputs (no undeclared keys -- miniwdl rejects those),
+#   * STAGES_IO_MAP_JSON: the stage-to-stage output->input handoff map the io-helper's
+#     link_outputs uses to thread each stage's miniwdl outputs into the next stage's File
+#     inputs (Download outputs -> Compress inputs -> Index inputs), and
+#   * the per-stage container-memory overrides the SFN template reads
+#     ($.DownloadEC2Memory / $.CompressEC2Memory / $.IndexSPOTMemory / $.IndexEC2Memory).
+#
+# The File hand-offs (download_out_* / compress_out_*) are NOT set here: they are populated
+# at runtime by the io-helper from the prior stage's outputs via STAGES_IO_MAP below, so the
+# per-stage inputs intentionally omit them.
 
-# Sub-WDL filenames per stage, resolved under the versioned workflows prefix. Kept here as
-# the single place to reconcile with the seqtoid-workflows WDL split.
+# Sub-WDL filename per stage, resolved under the versioned workflows prefix. Single place to
+# reconcile with the seqtoid-workflows WDL split (download.wdl / compress.wdl / index.wdl).
 STAGE_WDL_FILENAMES = {
     "Download": "download.wdl",
     "Compress": "compress.wdl",
     "Index": "index.wdl",
+}
+
+# Stage-to-stage output->input handoff map consumed by the io-helper's link_outputs.
+# For each downstream stage, `{ <this stage's input name>: <prior stage's output name> }`.
+# Verified against the seqtoid-workflows sub-WDLs (index-generation/{download,compress,index}.wdl):
+#   download.wdl outputs: nt, nr, accession2taxid_nucl_gb/_nucl_wgs/_pdb/_prot, taxdump
+#   compress.wdl outputs: nt, nr, accession2taxid_nucl_gb/_nucl_wgs/_pdb/_prot, taxdump
+# so Compress reads download_out_* and Index reads compress_out_*.
+_PASSTHROUGH = [
+    "nt",
+    "nr",
+    "accession2taxid_nucl_gb",
+    "accession2taxid_nucl_wgs",
+    "accession2taxid_pdb",
+    "accession2taxid_prot",
+    "taxdump",
+]
+STAGES_IO_MAP = {
+    "Compress": {f"download_out_{name}": name for name in _PASSTHROUGH},
+    "Index": {f"compress_out_{name}": name for name in _PASSTHROUGH},
 }
 
 
@@ -39,59 +60,69 @@ def start_index_generation(event, *args):
     bucket = os.environ["BUCKET"]
     workflows_bucket = os.environ["S3_WORKFLOWS_BUCKET"]
 
-    # Per-stage container memory (MB). These override the swipe stage_memory_defaults for
-    # this run; the SFN template reads them as $.<Stage>EC2Memory / $.IndexSPOTMemory.
+    # Per-stage container memory (MB). The SFN template reads these as
+    # $.DownloadEC2Memory / $.CompressEC2Memory / $.IndexSPOTMemory / $.IndexEC2Memory.
     download_memory = int(os.environ["DOWNLOAD_MEMORY"])
     compress_memory = int(os.environ["COMPRESS_MEMORY"])
     index_spot_memory = int(os.environ["INDEX_SPOT_MEMORY"])
     index_ec2_memory = int(os.environ["INDEX_EC2_MEMORY"])
 
-    major_version = re.search(r"v(\d+)\..+", version).group(1)
-
     sfn = boto3.client("stepfunctions")
     s3 = boto3.client("s3")
 
+    # Seed the Index stage's incremental lineage build from the most recent prior run, if any.
+    previous_lineages = None
     pages = s3.get_paginator("list_objects_v2").paginate(
         Bucket=bucket,
         Prefix=f"ncbi-indexes-{deployment_environment}/",
     )
-
-    previous_lineages = None
     for page in pages:
-        for object in page["Contents"]:
-            key = object["Key"]
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
             if key.endswith("versioned-taxid-lineages.csv.gz") and (
                 not previous_lineages or key > previous_lineages
             ):
                 previous_lineages = key
 
     index_name = event["time"][:10]
-    s3_dir = f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/index-generation-{major_version}"
+    docker_image_id = f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/index-generation:{version}"
+    output_prefix = f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/"
 
     def wdl_uri(stage):
         return f"s3://{workflows_bucket}/index-generation-{version}/{STAGE_WDL_FILENAMES[stage]}"
 
-    # Common run inputs shared by every stage. The per-stage sub-WDLs (seqtoid-workflows WDL
-    # split) will consume the subset each phase needs; reconcile exact keys when they land.
-    common_run_input = {
-        "docker_image_id": f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/index-generation:{version}",
-        "write_to_db": True,
+    # Publish the stage handoff map so the io-helper's link_outputs can resolve it. Written
+    # under the run's OutputPrefix so it is co-located with the per-stage input/output JSONs.
+    stage_io_map_key = f"ncbi-indexes-{deployment_environment}/{index_name}/stage_io_map.json"
+    s3.put_object(
+        Bucket=bucket,
+        Key=stage_io_map_key,
+        Body=json.dumps(STAGES_IO_MAP).encode(),
+    )
+    stage_io_map_uri = f"s3://{bucket}/{stage_io_map_key}"
+
+    # Per-stage inputs: ONLY each sub-WDL's declared workflow inputs. provided_nt/provided_nr
+    # are intentionally omitted so Download pulls the full NT/NR from NCBI (the accession2taxid
+    # and taxdump inputs default to their NCBI URLs in download.wdl). The File hand-offs
+    # (download_out_* / compress_out_*) are injected at runtime via STAGES_IO_MAP.
+    index_input = {
+        "docker_image_id": docker_image_id,
         "index_name": index_name,
-        "env": deployment_environment,
-        "s3_dir": s3_dir,
-        "previous_lineages": f"s3://{bucket}/{previous_lineages}",
     }
+    if previous_lineages:
+        index_input["previous_lineages"] = f"s3://{bucket}/{previous_lineages}"
 
     input_dict = {
         "DOWNLOAD_WDL_URI": wdl_uri("Download"),
         "COMPRESS_WDL_URI": wdl_uri("Compress"),
         "INDEX_WDL_URI": wdl_uri("Index"),
+        "STAGES_IO_MAP_JSON": stage_io_map_uri,
         "Input": {
-            "Download": dict(common_run_input),
-            "Compress": dict(common_run_input),
-            "Index": dict(common_run_input),
+            "Download": {"docker_image_id": docker_image_id},
+            "Compress": {"docker_image_id": docker_image_id},
+            "Index": index_input,
         },
-        "OutputPrefix": f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/",
+        "OutputPrefix": output_prefix,
         # Per-stage container memory overrides consumed by the SFN template.
         "DownloadEC2Memory": download_memory,
         "CompressEC2Memory": compress_memory,

--- a/terraform/start_index_generation_lambda_src/test_main.py
+++ b/terraform/start_index_generation_lambda_src/test_main.py
@@ -1,0 +1,58 @@
+"""Contract test for the multi-stage start_index_generation lambda (CZID-774).
+Verifies the SFN input matches the deployed SWIPE io-helper contract:
+per-stage Input has only declared sub-WDL keys, STAGES_IO_MAP_JSON is emitted,
+and no undeclared keys (write_to_db/env/s3_dir) leak into any stage.
+"""
+import json, os, sys, types
+
+# stub boto3 before importing the handler
+captured = {"sfn_input": None, "put_objects": []}
+
+class FakePaginator:
+    def paginate(self, **kw): return [{"Contents": []}]  # no prior lineages
+class FakeS3:
+    def get_paginator(self, name): return FakePaginator()
+    def put_object(self, **kw): captured["put_objects"].append(kw)
+class FakeSFN:
+    def start_execution(self, **kw): captured["sfn_input"] = json.loads(kw["input"]); captured["exec_name"] = kw["name"]
+
+fake_boto3 = types.ModuleType("boto3")
+fake_boto3.client = lambda svc: FakeSFN() if svc == "stepfunctions" else FakeS3()
+sys.modules["boto3"] = fake_boto3
+
+os.environ.update({
+    "DEPLOYMENT_ENVIRONMENT": "dev",
+    "INDEX_GENERATION_SFN_ARN": "arn:aws:states:us-west-2:491013321714:stateMachine:idseq-swipe-dev-index-generation-wdl",
+    "INDEX_GENERATION_WORKFLOW_VERSION": "v2.4.8",
+    "AWS_REGION": "us-west-2",
+    "AWS_ACCOUNT_ID": "491013321714",
+    "BUCKET": "seqtoid-public-references",
+    "S3_WORKFLOWS_BUCKET": "seqtoid-workflows-dev-491013321714",
+    "DOWNLOAD_MEMORY": "14000", "COMPRESS_MEMORY": "380000",
+    "INDEX_SPOT_MEMORY": "128000", "INDEX_EC2_MEMORY": "250000",
+})
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import main
+main.start_index_generation({"time": "2026-07-21T08:00:00Z"})
+
+d = captured["sfn_input"]
+print(json.dumps(d, indent=2))
+# assertions
+assert set(d) == {"DOWNLOAD_WDL_URI","COMPRESS_WDL_URI","INDEX_WDL_URI","STAGES_IO_MAP_JSON","Input","OutputPrefix","DownloadEC2Memory","CompressEC2Memory","IndexSPOTMemory","IndexEC2Memory"}, "top-level keys"
+assert d["DOWNLOAD_WDL_URI"].endswith("index-generation-v2.4.8/download.wdl")
+assert d["INDEX_WDL_URI"].endswith("index-generation-v2.4.8/index.wdl")
+# per-stage inputs carry ONLY declared keys, NO undeclared keys
+assert d["Input"]["Download"] == {"docker_image_id": "491013321714.dkr.ecr.us-west-2.amazonaws.com/index-generation:v2.4.8"}
+assert d["Input"]["Compress"] == {"docker_image_id": "491013321714.dkr.ecr.us-west-2.amazonaws.com/index-generation:v2.4.8"}
+assert set(d["Input"]["Index"]) == {"docker_image_id","index_name"}, "Index keys (no previous_lineages since none prior)"
+assert d["Input"]["Index"]["index_name"] == "2026-07-21"
+for stage in ("Download","Compress","Index"):
+    for bad in ("write_to_db","env","s3_dir"):
+        assert bad not in d["Input"][stage], f"{bad} leaked into {stage}"
+assert d["DownloadEC2Memory"]==14000 and d["CompressEC2Memory"]==380000 and d["IndexSPOTMemory"]==128000 and d["IndexEC2Memory"]==250000
+# io-map written to S3 + referenced
+assert captured["put_objects"], "io-map put_object called"
+iomap = json.loads(captured["put_objects"][0]["Body"].decode())
+assert iomap["Compress"]["download_out_nt"]=="nt" and iomap["Index"]["compress_out_taxdump"]=="taxdump"
+assert d["STAGES_IO_MAP_JSON"].endswith("2026-07-21/stage_io_map.json")
+print("\nALL ASSERTIONS PASSED")


### PR DESCRIPTION
The multi-stage `start_index_generation` lambda built an SFN input the deployed SWIPE io-helper cannot run: it set `Input.Download == Input.Compress == Input.Index` to a common payload carrying **undeclared** keys (`write_to_db`, `env`, `s3_dir`), supplied **no** `STAGES_IO_MAP_JSON`, and never provided the per-stage File hand-offs — so miniwdl rejected the run and the automated index-generation trigger could not produce a runnable execution.

Rewritten to the contract the deployed io-helper actually consumes:
- per-stage `Input.<Stage>` carries **only** that sub-WDL's declared workflow inputs (`docker_image_id`; Index also `index_name` + optional `previous_lineages`);
- emits `STAGES_IO_MAP_JSON` (written to S3 under `OutputPrefix`) so the io-helper's `link_outputs` threads Download outputs → Compress inputs → Index inputs (`download_out_*` / `compress_out_*`), verified against the seqtoid-workflows sub-WDL output names;
- drops `write_to_db`/`env`/`s3_dir` (not declared by any sub-WDL);
- keeps the per-stage memory overrides the SFN template reads.

Adds `test_main.py`, a contract unit test asserting the emitted shape and that no undeclared keys leak into any stage (passes).

**Stacked** on `czid-767-graviton-per-stage` (Track A + Graviton), which stacks on the Track A split (not yet on integration). Tracking: platform-overhaul CZID-774.