### PR TITLE
feat(index-generation): dedicated arm64 (Graviton) Batch job-def (CZID-776)

### DIFF
--- a/terraform/index-generation-arm64-jobdef.tf
+++ b/terraform/index-generation-arm64-jobdef.tf
@@ -1,0 +1,42 @@
+# Dedicated arm64 (Graviton) Batch job definition for the multi-stage index-generation stages
+# (Lever 2, CZID-776).
+#
+# The shared swipe main job-def (idseq-swipe-dev-main) runs the amd64 SWIPE runner image
+# (ghcr.io/chanzuckerberg/swipe:v1.4.9). AWS Batch launches THAT orchestrator image (not our
+# per-task index-generation image), and it is amd64-only, so on the arm64/Graviton
+# index-generation compute environments it dies with `exec /usr/local/bin/init.sh: exec format
+# error`. This job-def is a clone of the deployed swipe_main container properties with the
+# image -- and MINIWDL__S3PARCP__DOCKER_IMAGE (s3parcp runs the same swipe image) -- swapped to
+# the arm64 SWIPE runner published to dev ECR from the thorvath-slower/swipe fork
+# (swipe:v1.4.9-seqtoid.1-arm64, TARGETARCH-parameterized; base/miniwdl unchanged).
+#
+# ONLY the index-generation SFN is pointed at this job-def (via swipe.tf extra_template_vars);
+# short-read-mngs keeps the shared amd64 swipe_main job-def untouched, so nothing on x86
+# changes.
+#
+# NOTE: container_properties is a captured snapshot of idseq-swipe-dev-main (rev 7) with the two
+# image fields swapped -- it reuses the existing idseq-swipe-dev-batch-job role (baked in the
+# JSON) and all 23 env vars / mounts / ulimits verbatim. If the swipe main job-def config
+# changes, regenerate the JSON. Long-term this dedicated job-def is retired in favour of a
+# multi-arch swipe image + module support (CZID-777).
+
+resource "aws_batch_job_definition" "index_generation_arm64" {
+  name = "idseq-swipe-${var.DEPLOYMENT_ENVIRONMENT}-index-generation-arm64"
+  type = "container"
+  tags = { Name = "swipe" }
+
+  retry_strategy {
+    # Matches swipe_main: retries are configured in the SFN, not the job.
+    attempts = 1
+  }
+
+  timeout {
+    attempt_duration_seconds = 86400
+  }
+
+  container_properties = file("${path.module}/index_generation_arm64_container_properties.json")
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/index_generation_arm64_container_properties.json
+++ b/terraform/index_generation_arm64_container_properties.json
@@ -1,0 +1,138 @@
+{
+  "command": [],
+  "environment": [
+    {
+      "name": "MINIWDL__DOCKER_SWARM__ALLOW_NETWORKS",
+      "value": "[]"
+    },
+    {
+      "name": "MINIWDL__DOWNLOAD_CACHE__DIR",
+      "value": "/mnt/download_cache"
+    },
+    {
+      "name": "WDL_PASSTHRU_ENVVARS",
+      "value": "DEPLOYMENT_ENVIRONMENT"
+    },
+    {
+      "name": "WDL_WORKFLOW_URI",
+      "value": "Set this variable to the S3 URI of the WDL workflow"
+    },
+    {
+      "name": "MINIWDL__S3PARCP__DOCKER_IMAGE",
+      "value": "491013321714.dkr.ecr.us-west-2.amazonaws.com/swipe:v1.4.9-seqtoid.1-arm64"
+    },
+    {
+      "name": "MINIWDL__CALL_CACHE__PUT",
+      "value": "true"
+    },
+    {
+      "name": "MINIWDL__DOWNLOAD_CACHE__DISABLE_PATTERNS",
+      "value": "[\"s3://swipe-samples-*/*\"]"
+    },
+    {
+      "name": "MINIWDL__DOWNLOAD_CACHE__PUT",
+      "value": "true"
+    },
+    {
+      "name": "APP_NAME",
+      "value": "idseq-swipe-dev"
+    },
+    {
+      "name": "AWS_DEFAULT_REGION",
+      "value": "us-west-2"
+    },
+    {
+      "name": "DEPLOYMENT_ENVIRONMENT",
+      "value": "dev"
+    },
+    {
+      "name": "SFN_EXECUTION_ID",
+      "value": "Set this variable to the current step function execution ARN"
+    },
+    {
+      "name": "MINIWDL__CALL_CACHE__GET",
+      "value": "true"
+    },
+    {
+      "name": "DOWNLOAD_CACHE_MAX_GB",
+      "value": "500"
+    },
+    {
+      "name": "WDL_INPUT_URI",
+      "value": "Set this variable to the S3 URI of the WDL input JSON"
+    },
+    {
+      "name": "MINIWDL__CALL_CACHE__BACKEND",
+      "value": "s3_progressive_upload_call_cache_backend"
+    },
+    {
+      "name": "WDL_OUTPUT_URI",
+      "value": "Set this variable to the S3 URI where the WDL output JSON will be written"
+    },
+    {
+      "name": "MINIWDL__DOWNLOAD_CACHE__GET",
+      "value": "true"
+    },
+    {
+      "name": "MINIWDL__S3PARCP__DIR",
+      "value": "/mnt"
+    },
+    {
+      "name": "MINIWDL_DIR",
+      "value": "/mnt"
+    },
+    {
+      "name": "OUTPUT_STATUS_JSON_FILES",
+      "value": "true"
+    },
+    {
+      "name": "SFN_CURRENT_STATE",
+      "value": "Set this variable to the current step function state name, like HostFilterEC2 or HostFilterSPOT"
+    },
+    {
+      "name": "MINIWDL__TASK_RUNTIME__DEFAULTS",
+      "value": "{}"
+    }
+  ],
+  "image": "491013321714.dkr.ecr.us-west-2.amazonaws.com/swipe:v1.4.9-seqtoid.1-arm64",
+  "jobRoleArn": "arn:aws:iam::491013321714:role/idseq-swipe-dev-batch-job",
+  "memory": 4,
+  "mountPoints": [
+    {
+      "containerPath": "/mnt",
+      "readOnly": false,
+      "sourceVolume": "scratch"
+    },
+    {
+      "containerPath": "/var/run/docker.sock",
+      "readOnly": false,
+      "sourceVolume": "docker_sock"
+    }
+  ],
+  "privileged": false,
+  "readonlyRootFilesystem": false,
+  "resourceRequirements": [],
+  "secrets": [],
+  "ulimits": [
+    {
+      "hardLimit": 100000,
+      "name": "nofile",
+      "softLimit": 100000
+    }
+  ],
+  "vcpus": 1,
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/mnt"
+      },
+      "name": "scratch"
+    },
+    {
+      "host": {
+        "sourcePath": "/var/run/docker.sock"
+      },
+      "name": "docker_sock"
+    }
+  ]
+}

--- a/terraform/swipe.tf
+++ b/terraform/swipe.tf
@@ -66,6 +66,12 @@ module "swipe" {
         "index_generation_compress_job_queue_arn" : aws_batch_job_queue.index_generation["compress"].arn,
         "index_generation_index_spot_job_queue_arn" : aws_batch_job_queue.index_generation["index_spot"].arn,
         "index_generation_index_on_demand_job_queue_arn" : aws_batch_job_queue.index_generation["index_ondemand"].arn,
+        # Graviton (Lever 2, CZID-776): override the shared amd64 swipe_main job-def with the
+        # dedicated arm64 job-def for index-generation only. swipe-sfn renders the template with
+        # merge({batch_job_definition_name = <swipe_main>...}, extra_template_vars), and merge's
+        # second arg wins, so this replaces batch_job_definition_name for THIS SFN alone. The
+        # arm64 CEs (r7g/m7g) can only exec the arm64 SWIPE runner; short-read-mngs is untouched.
+        "batch_job_definition_name" : aws_batch_job_definition.index_generation_arm64.name,
       },
     },
   }


### PR DESCRIPTION
Unblocks running the multi-stage index-generation pipeline on the arm64/Graviton compute environments.

AWS Batch launches the **SWIPE orchestrator image** (not our per-task image) for every stage. The shared `swipe_main` job-def runs the amd64 `swipe:v1.4.9` runner, which cannot exec on arm64 hosts — the entrypoint dies with `exec /usr/local/bin/init.sh: exec format error` (that is what failed the first Graviton smoke).

Adds a dedicated arm64 job-def (`idseq-swipe-<env>-index-generation-arm64`) that clones the deployed `swipe_main` container properties with the image — and `MINIWDL__S3PARCP__DOCKER_IMAGE` (s3parcp runs the same swipe image) — swapped to the arm64 SWIPE runner in dev ECR (`swipe:v1.4.9-seqtoid.1-arm64`, built from thorvath-slower/swipe PR #2). All 23 env vars, mounts, ulimits, and the existing batch-job IAM role are preserved verbatim.

Points **only** the index-generation SFN at it, via `extra_template_vars` — swipe-sfn renders the template with `merge({batch_job_definition_name = <swipe_main>}, extra_template_vars)` and merge's second arg wins, so this overrides the job-def for this SFN alone. **short-read-mngs keeps the shared amd64 job-def untouched.**

Scoped plan/apply: **1 add / 1 change / 0 destroy** (new job-def + the index-gen SFN's 4 stage `JobDefinition` refs flip to the arm64 job-def).

`container_properties` is a captured snapshot of `idseq-swipe-dev-main` rev 7; long-term this is retired in favour of a multi-arch swipe image + module support (CZID-777).

Tracking: platform-overhaul CZID-776.