### PR TITLE
fix(index-generation): size Download stage scratch for a full core_nt+nr pull (500GB -> 2TB)

### DIFF
--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -41,8 +41,14 @@ locals {
       instance_types_x86      = ["c6i.2xlarge"] # 8 vCPU / 16 GB
       instance_types_graviton = ["m7g.2xlarge"] # 8 vCPU / 32 GB (Graviton3)
       max_vcpus               = 8
-      scratch_gb              = 500
-      provisioning            = "EC2"
+      # The Download stage runs update_blastdb.pl (compressed BLAST db volumes) THEN
+      # blastdbcmd -entry all -out <db>.fsa for BOTH nt/core_nt AND full nr on the same box.
+      # The first real core_nt+nr pull needed ~733 GB (compressed dbs + both uncompressed
+      # fasta dumps); the original 500 GB filled up mid-download ("Need 732963945407 bytes,
+      # only 253963251712 available"). 2 TB gives headroom for NR/core_nt growth and matches
+      # the index stages. IO-bound, so the bigger gp3 volume is cheap.
+      scratch_gb   = 2048
+      provisioning = "EC2"
     }
     compress = {
       instance_types_x86      = ["r6i.12xlarge"] # 48 vCPU / 384 GB

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -208,6 +208,12 @@ resource "aws_launch_template" "index_generation" {
   name      = "${local.service_name}-${each.key}-batch-${local.launch_template_user_data_hash}"
   user_data = filebase64(local.launch_template_user_data_file)
 
+  # Make each new launch-template version the DEFAULT so the Batch compute environment (which
+  # references this template by name, i.e. its default version) actually picks up changes -- e.g.
+  # the download scratch bump. Without this, a config change creates a new version but the CE keeps
+  # launching instances from the stale default (the 500 GB -> 2 TB download fix would not take).
+  update_default_version = true
+
   # NOTE[JH]: This setting makes IMDSv2 required. Any software that needs to talk to the metadata service
   # needs to do so using the v2 endpoint.
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html


### PR DESCRIPTION
First real core_nt build failed at Download: `Need 732963945407 bytes and only 253963251712 bytes are available` -- the Download stage's 500 GB gp3 scratch filled mid-pull.

The Download stage runs `update_blastdb.pl` (compressed BLAST db volumes) then `blastdbcmd -entry all -out <db>.fsa` for **both** nt/core_nt **and** full nr on one box; the working set is ~733 GB. Bump `download.scratch_gb` 500 -> 2048 (matches the index stages; IO-bound so the larger gp3 is cheap).

Everything else validated: the arm64 Download stage pulled real core_nt + nr + taxonomy for ~80 min on Graviton before hitting the wall -- this is pure right-sizing calibration, which the first real run exists to surface.