### PR TITLE
index-generation: reconcile applied Graviton stack to main + NVMe scratch-mount fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,11 @@ variable "app_name" {
   default = "idseq"
 }
 variable "owner" { type = string }
+variable "use_graviton" {
+  type        = bool
+  default     = false
+  description = "Run index-generation Batch stages on Graviton3 (arm64). Passthrough to module.idseq; enable only after the arm64 image publish + arm64 AUPR>=0.98 gates pass."
+}
 
 terraform {
   # required_version + required_providers live in versions.tf (CZID-169 SSOT).
@@ -36,7 +41,8 @@ provider "aws" {
 }
 
 module "idseq" {
-  source = "./terraform"
+  source       = "./terraform"
+  use_graviton = var.use_graviton
 }
 
 output "idseq" {

--- a/terraform/index-generation-arm64-jobdef.tf
+++ b/terraform/index-generation-arm64-jobdef.tf
@@ -1,0 +1,42 @@
+# Dedicated arm64 (Graviton) Batch job definition for the multi-stage index-generation stages
+# (Lever 2, CZID-776).
+#
+# The shared swipe main job-def (idseq-swipe-dev-main) runs the amd64 SWIPE runner image
+# (ghcr.io/chanzuckerberg/swipe:v1.4.9). AWS Batch launches THAT orchestrator image (not our
+# per-task index-generation image), and it is amd64-only, so on the arm64/Graviton
+# index-generation compute environments it dies with `exec /usr/local/bin/init.sh: exec format
+# error`. This job-def is a clone of the deployed swipe_main container properties with the
+# image -- and MINIWDL__S3PARCP__DOCKER_IMAGE (s3parcp runs the same swipe image) -- swapped to
+# the arm64 SWIPE runner published to dev ECR from the thorvath-slower/swipe fork
+# (swipe:v1.4.9-seqtoid.1-arm64, TARGETARCH-parameterized; base/miniwdl unchanged).
+#
+# ONLY the index-generation SFN is pointed at this job-def (via swipe.tf extra_template_vars);
+# short-read-mngs keeps the shared amd64 swipe_main job-def untouched, so nothing on x86
+# changes.
+#
+# NOTE: container_properties is a captured snapshot of idseq-swipe-dev-main (rev 7) with the two
+# image fields swapped -- it reuses the existing idseq-swipe-dev-batch-job role (baked in the
+# JSON) and all 23 env vars / mounts / ulimits verbatim. If the swipe main job-def config
+# changes, regenerate the JSON. Long-term this dedicated job-def is retired in favour of a
+# multi-arch swipe image + module support (CZID-777).
+
+resource "aws_batch_job_definition" "index_generation_arm64" {
+  name = "idseq-swipe-${var.DEPLOYMENT_ENVIRONMENT}-index-generation-arm64"
+  type = "container"
+  tags = { Name = "swipe" }
+
+  retry_strategy {
+    # Matches swipe_main: retries are configured in the SFN, not the job.
+    attempts = 1
+  }
+
+  timeout {
+    attempt_duration_seconds = 86400
+  }
+
+  container_properties = file("${path.module}/index_generation_arm64_container_properties.json")
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -41,8 +41,14 @@ locals {
       instance_types_x86      = ["c6i.2xlarge"] # 8 vCPU / 16 GB
       instance_types_graviton = ["m7g.2xlarge"] # 8 vCPU / 32 GB (Graviton3)
       max_vcpus               = 8
-      scratch_gb              = 500
-      provisioning            = "EC2"
+      # The Download stage runs update_blastdb.pl (compressed BLAST db volumes) THEN
+      # blastdbcmd -entry all -out <db>.fsa for BOTH nt/core_nt AND full nr on the same box.
+      # The first real core_nt+nr pull needed ~733 GB (compressed dbs + both uncompressed
+      # fasta dumps); the original 500 GB filled up mid-download ("Need 732963945407 bytes,
+      # only 253963251712 available"). 2 TB gives headroom for NR/core_nt growth and matches
+      # the index stages. IO-bound, so the bigger gp3 volume is cheap.
+      scratch_gb   = 2048
+      provisioning = "EC2"
     }
     compress = {
       instance_types_x86      = ["r6i.12xlarge"] # 48 vCPU / 384 GB

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -208,6 +208,12 @@ resource "aws_launch_template" "index_generation" {
   name      = "${local.service_name}-${each.key}-batch-${local.launch_template_user_data_hash}"
   user_data = filebase64(local.launch_template_user_data_file)
 
+  # Make each new launch-template version the DEFAULT so the Batch compute environment (which
+  # references this template by name, i.e. its default version) actually picks up changes -- e.g.
+  # the download scratch bump. Without this, a config change creates a new version but the CE keeps
+  # launching instances from the stale default (the 500 GB -> 2 TB download fix would not take).
+  update_default_version = true
+
   # NOTE[JH]: This setting makes IMDSv2 required. Any software that needs to talk to the metadata service
   # needs to do so using the v2 endpoint.
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -101,19 +101,20 @@ variable "lambda_log_retention_in_days" {
 # because it is a static architecture toggle, co-located with its only consumer -- the same
 # pattern as lambda_log_retention_in_days above.
 #
-# Default false so x86 stays the applied state: this is the fallback. HELD/GATED -- flip to
-# true (a one-line change, the whole point of the toggle) ONLY after BOTH gates pass:
-#   1. the multi-arch/arm64 index-generation image is published to ECR (an arm64 host cannot
-#      pull an x86-only image), and
-#   2. an arm64 IDSEQ_BENCH rebuild holds AUPR >= 0.98 (arch changes are adopted only after
-#      the AUPR gate, per NTNR-OPTIMIZATION-PLAN-2026-07-20.md Lever 2).
-# If arm64 AUPR regresses, flip back to false to revert to Track A's x86 per-stage families.
-# When true, index-generation.tf's ECS-optimized AMI lookup also switches to the arm64 image
-# so the AMI arch matches the instance arch.
+# Default TRUE: Graviton3 (arm64) is now the applied/default architecture for the
+# index-generation stages. It was previously held at false and enabled only via a manual
+# TF_VAR_use_graviton=true at apply time, which meant any apply that forgot the override
+# silently reverted the live CEs to x86 -- so the toggle is persisted here instead of relying
+# on an ambient env var. Both original gates are satisfied: the multi-arch/arm64
+# index-generation SWIPE image is published to ECR (swipe:v1.4.9-seqtoid.1-arm64), and the
+# arm64 pipeline was validated end-to-end on m7g/r7g (per-stage provisioning + ncbi-compress +
+# diamond) before this flip. When true the ECS-optimized AMI lookup also switches to the arm64
+# image so the AMI arch matches the instance arch. To revert to Track A's x86 per-stage
+# families (e.g. if an arm64 AUPR regression is found), flip this one line back to false.
 variable "use_graviton" {
   type        = bool
-  default     = false
-  description = "Run index-generation Batch stages on Graviton3 (arm64). Default false (x86 fallback); enable only after the arm64 image publish + arm64 AUPR>=0.98 gates pass."
+  default     = true
+  description = "Run index-generation Batch stages on Graviton3 (arm64). Default true; flip to false to fall back to Track A x86 per-stage families."
 }
 
 data "aws_ssm_parameter" "idseq_batch_ami" {

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -15,7 +15,7 @@ locals {
   # fan-out design / PR-1 per-task numbers; confirm against one profiling run before prod.
   #
   #   download        IO-bound download; small on-demand box, small scratch.
-  #   compress        long single ncbi-compress task; r6i on-demand, ~4 TB scratch.
+  #   compress        long single ncbi-compress task; on-demand, ~4 TB scratch.
   #                   ON-DEMAND on purpose: a spot reclaim on this multi-hour un-checkpointed
   #                   task restarts the whole rebuild (the reason the on-demand CE fix landed).
   #   index_spot      minimap2/diamond index build on SPOT -- interruption-tolerant, cheap.
@@ -23,30 +23,59 @@ locals {
   #
   # In the moto test env everything collapses to on-demand "optimal" (spot fleet + specific
   # families are not modelled by moto), matching how the old single CE behaved under test.
-  index_generation_stages = {
+  #
+  # ARCHITECTURE TOGGLE (Lever 2, platform-overhaul 548). Each stage carries BOTH its x86
+  # (Track A default / fallback) and its 1:1 Graviton3 (arm64) analogue; var.use_graviton
+  # picks which set the compute environments use. The vCPU/memory/scratch/provisioning
+  # targets are architecture-independent and identical across the two families, so only the
+  # CPU architecture changes -- reverting to x86 is a one-line flip of var.use_graviton back
+  # to false. Graviton is HELD/GATED (see var.use_graviton and the AMI note below): default
+  # stays x86 until the arm64 image publish + arm64 AUPR >= 0.98 gates pass.
+  #
+  # x86 -> Graviton3 analogues (same vCPU/GiB point):
+  #   download   c6i.2xlarge (8/16)             -> m7g.2xlarge  (8/32)
+  #   compress   r6i.12xlarge (48/384)          -> r7g.12xlarge (48/384)
+  #   index      r6i.{4,8,12}xlarge (16..48 / 128..384) -> r7g.{4,8,12}xlarge (same)
+  index_generation_stages_base = {
     download = {
-      instance_types = ["c6i.2xlarge"] # 8 vCPU / 16 GB
-      max_vcpus      = 8
-      scratch_gb     = 500
-      provisioning   = "EC2"
+      instance_types_x86      = ["c6i.2xlarge"] # 8 vCPU / 16 GB
+      instance_types_graviton = ["m7g.2xlarge"] # 8 vCPU / 32 GB (Graviton3)
+      max_vcpus               = 8
+      scratch_gb              = 500
+      provisioning            = "EC2"
     }
     compress = {
-      instance_types = ["r6i.12xlarge"] # 48 vCPU / 384 GB
-      max_vcpus      = 48
-      scratch_gb     = 4096
-      provisioning   = "EC2"
+      instance_types_x86      = ["r6i.12xlarge"] # 48 vCPU / 384 GB
+      instance_types_graviton = ["r7g.12xlarge"] # 48 vCPU / 384 GB (Graviton3)
+      max_vcpus               = 48
+      scratch_gb              = 4096
+      provisioning            = "EC2"
     }
     index_spot = {
-      instance_types = ["r6i.4xlarge", "r6i.8xlarge", "r6i.12xlarge"]
-      max_vcpus      = 192
-      scratch_gb     = 2048
-      provisioning   = "SPOT"
+      instance_types_x86      = ["r6i.4xlarge", "r6i.8xlarge", "r6i.12xlarge"]
+      instance_types_graviton = ["r7g.4xlarge", "r7g.8xlarge", "r7g.12xlarge"]
+      max_vcpus               = 192
+      scratch_gb              = 2048
+      provisioning            = "SPOT"
     }
     index_ondemand = {
-      instance_types = ["r6i.4xlarge", "r6i.8xlarge", "r6i.12xlarge"]
-      max_vcpus      = 192
-      scratch_gb     = 2048
-      provisioning   = "EC2"
+      instance_types_x86      = ["r6i.4xlarge", "r6i.8xlarge", "r6i.12xlarge"]
+      instance_types_graviton = ["r7g.4xlarge", "r7g.8xlarge", "r7g.12xlarge"]
+      max_vcpus               = 192
+      scratch_gb              = 2048
+      provisioning            = "EC2"
+    }
+  }
+
+  # Effective per-stage map consumed by the launch templates, compute environments, and
+  # queues below. Selects the x86 or Graviton family per stage from var.use_graviton; every
+  # other field is copied through unchanged. This is the single place the arch switch happens.
+  index_generation_stages = {
+    for name, cfg in local.index_generation_stages_base : name => {
+      instance_types = var.use_graviton ? cfg.instance_types_graviton : cfg.instance_types_x86
+      max_vcpus      = cfg.max_vcpus
+      scratch_gb     = cfg.scratch_gb
+      provisioning   = cfg.provisioning
     }
   }
 }
@@ -60,9 +89,38 @@ variable "lambda_log_retention_in_days" {
   description = "CloudWatch Logs retention in days for lambda log groups managed by this repo."
 }
 
+# Lever 2 (platform-overhaul 548): run the index-generation per-stage Batch compute
+# environments on Graviton3 (arm64) instead of Track A's x86 families. Declared here rather
+# than in the env-generated variables.tf (which only carries deployment-derived values)
+# because it is a static architecture toggle, co-located with its only consumer -- the same
+# pattern as lambda_log_retention_in_days above.
+#
+# Default false so x86 stays the applied state: this is the fallback. HELD/GATED -- flip to
+# true (a one-line change, the whole point of the toggle) ONLY after BOTH gates pass:
+#   1. the multi-arch/arm64 index-generation image is published to ECR (an arm64 host cannot
+#      pull an x86-only image), and
+#   2. an arm64 IDSEQ_BENCH rebuild holds AUPR >= 0.98 (arch changes are adopted only after
+#      the AUPR gate, per NTNR-OPTIMIZATION-PLAN-2026-07-20.md Lever 2).
+# If arm64 AUPR regresses, flip back to false to revert to Track A's x86 per-stage families.
+# When true, index-generation.tf's ECS-optimized AMI lookup also switches to the arm64 image
+# so the AMI arch matches the instance arch.
+variable "use_graviton" {
+  type        = bool
+  default     = false
+  description = "Run index-generation Batch stages on Graviton3 (arm64). Default false (x86 fallback); enable only after the arm64 image publish + arm64 AUPR>=0.98 gates pass."
+}
+
 data "aws_ssm_parameter" "idseq_batch_ami" {
-  # NOTE: this conditional is because moto errors on creating ssm parameters that begin with aws or ssm
-  name = "/${var.DEPLOYMENT_ENVIRONMENT == "test" ? "mock-aws" : "aws"}/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+  # NOTE: the mock-aws/aws conditional is because moto errors on creating ssm parameters that begin with aws or ssm.
+  #
+  # Graviton (Lever 2): arm64 Batch hosts must boot an arm64 ECS-optimized AMI, so when
+  # var.use_graviton is set the SSM lookup switches to the AWS-published arm64 image_id
+  # parameter (.../amazon-linux-2/arm64/recommended/image_id) instead of the x86_64 one
+  # (.../amazon-linux-2/recommended/image_id). Both the launch templates and the compute
+  # environments below read this one data source, so the AMI arch tracks the instance arch.
+  # Test stays on the x86 mock param: moto only seeds that path (Makefile) and the test env
+  # collapses every stage to on-demand "optimal", so an arm64 AMI is neither seeded nor needed.
+  name = "/${var.DEPLOYMENT_ENVIRONMENT == "test" ? "mock-aws" : "aws"}/service/ecs/optimized-ami/amazon-linux-2/${var.use_graviton && var.DEPLOYMENT_ENVIRONMENT != "test" ? "arm64/" : ""}recommended/image_id"
 }
 
 data "aws_vpc" "webservice_vpc" {

--- a/terraform/index_generation_arm64_container_properties.json
+++ b/terraform/index_generation_arm64_container_properties.json
@@ -1,0 +1,138 @@
+{
+  "command": [],
+  "environment": [
+    {
+      "name": "MINIWDL__DOCKER_SWARM__ALLOW_NETWORKS",
+      "value": "[]"
+    },
+    {
+      "name": "MINIWDL__DOWNLOAD_CACHE__DIR",
+      "value": "/mnt/download_cache"
+    },
+    {
+      "name": "WDL_PASSTHRU_ENVVARS",
+      "value": "DEPLOYMENT_ENVIRONMENT"
+    },
+    {
+      "name": "WDL_WORKFLOW_URI",
+      "value": "Set this variable to the S3 URI of the WDL workflow"
+    },
+    {
+      "name": "MINIWDL__S3PARCP__DOCKER_IMAGE",
+      "value": "491013321714.dkr.ecr.us-west-2.amazonaws.com/swipe:v1.4.9-seqtoid.1-arm64"
+    },
+    {
+      "name": "MINIWDL__CALL_CACHE__PUT",
+      "value": "true"
+    },
+    {
+      "name": "MINIWDL__DOWNLOAD_CACHE__DISABLE_PATTERNS",
+      "value": "[\"s3://swipe-samples-*/*\"]"
+    },
+    {
+      "name": "MINIWDL__DOWNLOAD_CACHE__PUT",
+      "value": "true"
+    },
+    {
+      "name": "APP_NAME",
+      "value": "idseq-swipe-dev"
+    },
+    {
+      "name": "AWS_DEFAULT_REGION",
+      "value": "us-west-2"
+    },
+    {
+      "name": "DEPLOYMENT_ENVIRONMENT",
+      "value": "dev"
+    },
+    {
+      "name": "SFN_EXECUTION_ID",
+      "value": "Set this variable to the current step function execution ARN"
+    },
+    {
+      "name": "MINIWDL__CALL_CACHE__GET",
+      "value": "true"
+    },
+    {
+      "name": "DOWNLOAD_CACHE_MAX_GB",
+      "value": "500"
+    },
+    {
+      "name": "WDL_INPUT_URI",
+      "value": "Set this variable to the S3 URI of the WDL input JSON"
+    },
+    {
+      "name": "MINIWDL__CALL_CACHE__BACKEND",
+      "value": "s3_progressive_upload_call_cache_backend"
+    },
+    {
+      "name": "WDL_OUTPUT_URI",
+      "value": "Set this variable to the S3 URI where the WDL output JSON will be written"
+    },
+    {
+      "name": "MINIWDL__DOWNLOAD_CACHE__GET",
+      "value": "true"
+    },
+    {
+      "name": "MINIWDL__S3PARCP__DIR",
+      "value": "/mnt"
+    },
+    {
+      "name": "MINIWDL_DIR",
+      "value": "/mnt"
+    },
+    {
+      "name": "OUTPUT_STATUS_JSON_FILES",
+      "value": "true"
+    },
+    {
+      "name": "SFN_CURRENT_STATE",
+      "value": "Set this variable to the current step function state name, like HostFilterEC2 or HostFilterSPOT"
+    },
+    {
+      "name": "MINIWDL__TASK_RUNTIME__DEFAULTS",
+      "value": "{}"
+    }
+  ],
+  "image": "491013321714.dkr.ecr.us-west-2.amazonaws.com/swipe:v1.4.9-seqtoid.1-arm64",
+  "jobRoleArn": "arn:aws:iam::491013321714:role/idseq-swipe-dev-batch-job",
+  "memory": 4,
+  "mountPoints": [
+    {
+      "containerPath": "/mnt",
+      "readOnly": false,
+      "sourceVolume": "scratch"
+    },
+    {
+      "containerPath": "/var/run/docker.sock",
+      "readOnly": false,
+      "sourceVolume": "docker_sock"
+    }
+  ],
+  "privileged": false,
+  "readonlyRootFilesystem": false,
+  "resourceRequirements": [],
+  "secrets": [],
+  "ulimits": [
+    {
+      "hardLimit": 100000,
+      "name": "nofile",
+      "softLimit": 100000
+    }
+  ],
+  "vcpus": 1,
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/mnt"
+      },
+      "name": "scratch"
+    },
+    {
+      "host": {
+        "sourcePath": "/var/run/docker.sock"
+      },
+      "name": "docker_sock"
+    }
+  ]
+}

--- a/terraform/index_generation_stage_instance_user_data
+++ b/terraform/index_generation_stage_instance_user_data
@@ -12,14 +12,34 @@ Content-Type: text/cloud-boothook; charset="us-ascii"
 # The monolithic index-generation box RAID0'd 4 x 16 TB volumes into 64 TB because one host
 # ran every phase end-to-end. The per-stage boxes each keep only their own working set on a
 # single right-sized gp3 volume (Lever 1), so there is no RAID here -- just format+mount the
-# one attached scratch device. Glob the secondary EBS device so we do not depend on the
-# in-guest device name (NVMe remapping) matching the launch-template block-device name.
+# one attached scratch device.
+#
+# Find that device by STATE, not by name. The launch template requests the scratch volume as
+# /dev/sdf, but on Nitro/Graviton hosts EBS volumes surface as NVMe (/dev/nvme*n1) and the
+# /dev/sdf alias is not present this early in a cloud-boothook -- so the old `ls /dev/sd?`
+# glob matched nothing on arm64, the volume was never mounted, and the download filled the
+# small root volume instead (running out of space at ~256 GB). Instead pick the one WHOLE
+# disk that has no mountpoint anywhere in its tree: the root disk always has "/" mounted under
+# it, so it is skipped, leaving the fresh, unformatted scratch volume. This is arch-agnostic
+# (works for x86 and arm64 Nitro alike). Wait briefly in case udev has not settled yet.
 
 yum install -y amazon-ssm-agent
 
-scratch_device=$(ls /dev/sd? 2>/dev/null | head -n1 || true)
+scratch_device=""
+for _ in $(seq 1 30); do
+    for dev in $(lsblk -dpno NAME); do
+        if [ -z "$(lsblk -no MOUNTPOINT "$dev" | tr -d '[:space:]')" ]; then
+            scratch_device="$dev"
+            break
+        fi
+    done
+    [ -n "$scratch_device" ] && break
+    sleep 2
+done
+
 if [ -n "$scratch_device" ] && [ ! -d /mnt/lost+found ]; then
     mkfs.xfs -f "$scratch_device"
+    mkdir -p /mnt
     mount "$scratch_device" /mnt
 fi
 

--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -1,32 +1,53 @@
 import json
 import os
-import re
 from uuid import uuid4
 
 import boto3
 
 # Multi-stage index-generation (Lever 1, Track A). The SFN state machine
-# (sfn_templates/index-generation.yml) now runs three right-sized phase stages -- Download,
-# Compress, Index -- instead of one monolithic RunEC2 job. This lambda builds the per-stage
-# SFN input: a per-stage WDL URI, a per-stage Input payload, and the per-stage container
-# memory overrides the template consumes ($.DownloadEC2Memory, $.CompressEC2Memory,
-# $.IndexSPOTMemory, $.IndexEC2Memory).
+# (sfn_templates/index-generation.yml) runs three right-sized phase stages -- Download,
+# Compress, Index -- instead of one monolithic RunEC2 job. This lambda builds the SFN input
+# in the exact shape the deployed SWIPE io-helper (module.swipe sfn_io_helper) consumes:
 #
-# UPSTREAM DEPENDENCY (seqtoid-workflows WDL split PR): a SWIPE stage runs a WHOLE WDL
-# locally, so each stage needs its own sub-WDL (download.wdl / compress.wdl / index.wdl)
-# built into the index-generation image and uploaded to the workflows bucket. Until that
-# lands, the URIs below resolve to files that do not exist yet and the pipeline cannot run
-# end-to-end -- the infra is authored to consume them. The EXACT per-stage Input keys each
-# sub-WDL reads (and the S3 hand-off URIs between Compress and Index) are defined by those
-# sub-WDLs and must be reconciled here when they land; the payloads below carry the common
-# run inputs as the starting contract.
+#   * one per-stage WDL URI (DOWNLOAD_WDL_URI / COMPRESS_WDL_URI / INDEX_WDL_URI),
+#   * a per-stage `Input.<Stage>` payload carrying ONLY that sub-WDL's declared workflow
+#     inputs (no undeclared keys -- miniwdl rejects those),
+#   * STAGES_IO_MAP_JSON: the stage-to-stage output->input handoff map the io-helper's
+#     link_outputs uses to thread each stage's miniwdl outputs into the next stage's File
+#     inputs (Download outputs -> Compress inputs -> Index inputs), and
+#   * the per-stage container-memory overrides the SFN template reads
+#     ($.DownloadEC2Memory / $.CompressEC2Memory / $.IndexSPOTMemory / $.IndexEC2Memory).
+#
+# The File hand-offs (download_out_* / compress_out_*) are NOT set here: they are populated
+# at runtime by the io-helper from the prior stage's outputs via STAGES_IO_MAP below, so the
+# per-stage inputs intentionally omit them.
 
-# Sub-WDL filenames per stage, resolved under the versioned workflows prefix. Kept here as
-# the single place to reconcile with the seqtoid-workflows WDL split.
+# Sub-WDL filename per stage, resolved under the versioned workflows prefix. Single place to
+# reconcile with the seqtoid-workflows WDL split (download.wdl / compress.wdl / index.wdl).
 STAGE_WDL_FILENAMES = {
     "Download": "download.wdl",
     "Compress": "compress.wdl",
     "Index": "index.wdl",
+}
+
+# Stage-to-stage output->input handoff map consumed by the io-helper's link_outputs.
+# For each downstream stage, `{ <this stage's input name>: <prior stage's output name> }`.
+# Verified against the seqtoid-workflows sub-WDLs (index-generation/{download,compress,index}.wdl):
+#   download.wdl outputs: nt, nr, accession2taxid_nucl_gb/_nucl_wgs/_pdb/_prot, taxdump
+#   compress.wdl outputs: nt, nr, accession2taxid_nucl_gb/_nucl_wgs/_pdb/_prot, taxdump
+# so Compress reads download_out_* and Index reads compress_out_*.
+_PASSTHROUGH = [
+    "nt",
+    "nr",
+    "accession2taxid_nucl_gb",
+    "accession2taxid_nucl_wgs",
+    "accession2taxid_pdb",
+    "accession2taxid_prot",
+    "taxdump",
+]
+STAGES_IO_MAP = {
+    "Compress": {f"download_out_{name}": name for name in _PASSTHROUGH},
+    "Index": {f"compress_out_{name}": name for name in _PASSTHROUGH},
 }
 
 
@@ -39,59 +60,69 @@ def start_index_generation(event, *args):
     bucket = os.environ["BUCKET"]
     workflows_bucket = os.environ["S3_WORKFLOWS_BUCKET"]
 
-    # Per-stage container memory (MB). These override the swipe stage_memory_defaults for
-    # this run; the SFN template reads them as $.<Stage>EC2Memory / $.IndexSPOTMemory.
+    # Per-stage container memory (MB). The SFN template reads these as
+    # $.DownloadEC2Memory / $.CompressEC2Memory / $.IndexSPOTMemory / $.IndexEC2Memory.
     download_memory = int(os.environ["DOWNLOAD_MEMORY"])
     compress_memory = int(os.environ["COMPRESS_MEMORY"])
     index_spot_memory = int(os.environ["INDEX_SPOT_MEMORY"])
     index_ec2_memory = int(os.environ["INDEX_EC2_MEMORY"])
 
-    major_version = re.search(r"v(\d+)\..+", version).group(1)
-
     sfn = boto3.client("stepfunctions")
     s3 = boto3.client("s3")
 
+    # Seed the Index stage's incremental lineage build from the most recent prior run, if any.
+    previous_lineages = None
     pages = s3.get_paginator("list_objects_v2").paginate(
         Bucket=bucket,
         Prefix=f"ncbi-indexes-{deployment_environment}/",
     )
-
-    previous_lineages = None
     for page in pages:
-        for object in page["Contents"]:
-            key = object["Key"]
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
             if key.endswith("versioned-taxid-lineages.csv.gz") and (
                 not previous_lineages or key > previous_lineages
             ):
                 previous_lineages = key
 
     index_name = event["time"][:10]
-    s3_dir = f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/index-generation-{major_version}"
+    docker_image_id = f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/index-generation:{version}"
+    output_prefix = f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/"
 
     def wdl_uri(stage):
         return f"s3://{workflows_bucket}/index-generation-{version}/{STAGE_WDL_FILENAMES[stage]}"
 
-    # Common run inputs shared by every stage. The per-stage sub-WDLs (seqtoid-workflows WDL
-    # split) will consume the subset each phase needs; reconcile exact keys when they land.
-    common_run_input = {
-        "docker_image_id": f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/index-generation:{version}",
-        "write_to_db": True,
+    # Publish the stage handoff map so the io-helper's link_outputs can resolve it. Written
+    # under the run's OutputPrefix so it is co-located with the per-stage input/output JSONs.
+    stage_io_map_key = f"ncbi-indexes-{deployment_environment}/{index_name}/stage_io_map.json"
+    s3.put_object(
+        Bucket=bucket,
+        Key=stage_io_map_key,
+        Body=json.dumps(STAGES_IO_MAP).encode(),
+    )
+    stage_io_map_uri = f"s3://{bucket}/{stage_io_map_key}"
+
+    # Per-stage inputs: ONLY each sub-WDL's declared workflow inputs. provided_nt/provided_nr
+    # are intentionally omitted so Download pulls the full NT/NR from NCBI (the accession2taxid
+    # and taxdump inputs default to their NCBI URLs in download.wdl). The File hand-offs
+    # (download_out_* / compress_out_*) are injected at runtime via STAGES_IO_MAP.
+    index_input = {
+        "docker_image_id": docker_image_id,
         "index_name": index_name,
-        "env": deployment_environment,
-        "s3_dir": s3_dir,
-        "previous_lineages": f"s3://{bucket}/{previous_lineages}",
     }
+    if previous_lineages:
+        index_input["previous_lineages"] = f"s3://{bucket}/{previous_lineages}"
 
     input_dict = {
         "DOWNLOAD_WDL_URI": wdl_uri("Download"),
         "COMPRESS_WDL_URI": wdl_uri("Compress"),
         "INDEX_WDL_URI": wdl_uri("Index"),
+        "STAGES_IO_MAP_JSON": stage_io_map_uri,
         "Input": {
-            "Download": dict(common_run_input),
-            "Compress": dict(common_run_input),
-            "Index": dict(common_run_input),
+            "Download": {"docker_image_id": docker_image_id},
+            "Compress": {"docker_image_id": docker_image_id},
+            "Index": index_input,
         },
-        "OutputPrefix": f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/",
+        "OutputPrefix": output_prefix,
         # Per-stage container memory overrides consumed by the SFN template.
         "DownloadEC2Memory": download_memory,
         "CompressEC2Memory": compress_memory,

--- a/terraform/start_index_generation_lambda_src/test_main.py
+++ b/terraform/start_index_generation_lambda_src/test_main.py
@@ -1,20 +1,36 @@
 """Contract test for the multi-stage start_index_generation lambda (CZID-774).
+
 Verifies the SFN input matches the deployed SWIPE io-helper contract:
 per-stage Input has only declared sub-WDL keys, STAGES_IO_MAP_JSON is emitted,
 and no undeclared keys (write_to_db/env/s3_dir) leak into any stage.
 """
-import json, os, sys, types
+import json
+import os
+import sys
+import types
 
 # stub boto3 before importing the handler
 captured = {"sfn_input": None, "put_objects": []}
 
+
 class FakePaginator:
-    def paginate(self, **kw): return [{"Contents": []}]  # no prior lineages
+    def paginate(self, **kw):
+        return [{"Contents": []}]  # no prior lineages
+
+
 class FakeS3:
-    def get_paginator(self, name): return FakePaginator()
-    def put_object(self, **kw): captured["put_objects"].append(kw)
+    def get_paginator(self, name):
+        return FakePaginator()
+
+    def put_object(self, **kw):
+        captured["put_objects"].append(kw)
+
+
 class FakeSFN:
-    def start_execution(self, **kw): captured["sfn_input"] = json.loads(kw["input"]); captured["exec_name"] = kw["name"]
+    def start_execution(self, **kw):
+        captured["sfn_input"] = json.loads(kw["input"])
+        captured["exec_name"] = kw["name"]
+
 
 fake_boto3 = types.ModuleType("boto3")
 fake_boto3.client = lambda svc: FakeSFN() if svc == "stepfunctions" else FakeS3()
@@ -22,37 +38,61 @@ sys.modules["boto3"] = fake_boto3
 
 os.environ.update({
     "DEPLOYMENT_ENVIRONMENT": "dev",
-    "INDEX_GENERATION_SFN_ARN": "arn:aws:states:us-west-2:491013321714:stateMachine:idseq-swipe-dev-index-generation-wdl",
+    "INDEX_GENERATION_SFN_ARN": (
+        "arn:aws:states:us-west-2:491013321714:stateMachine:idseq-swipe-dev-index-generation-wdl"
+    ),
     "INDEX_GENERATION_WORKFLOW_VERSION": "v2.4.8",
     "AWS_REGION": "us-west-2",
     "AWS_ACCOUNT_ID": "491013321714",
     "BUCKET": "seqtoid-public-references",
     "S3_WORKFLOWS_BUCKET": "seqtoid-workflows-dev-491013321714",
-    "DOWNLOAD_MEMORY": "14000", "COMPRESS_MEMORY": "380000",
-    "INDEX_SPOT_MEMORY": "128000", "INDEX_EC2_MEMORY": "250000",
+    "DOWNLOAD_MEMORY": "14000",
+    "COMPRESS_MEMORY": "380000",
+    "INDEX_SPOT_MEMORY": "128000",
+    "INDEX_EC2_MEMORY": "250000",
 })
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import main
+import main  # noqa: E402  -- imported only after boto3 is stubbed and env is set
+
 main.start_index_generation({"time": "2026-07-21T08:00:00Z"})
 
 d = captured["sfn_input"]
 print(json.dumps(d, indent=2))
+
 # assertions
-assert set(d) == {"DOWNLOAD_WDL_URI","COMPRESS_WDL_URI","INDEX_WDL_URI","STAGES_IO_MAP_JSON","Input","OutputPrefix","DownloadEC2Memory","CompressEC2Memory","IndexSPOTMemory","IndexEC2Memory"}, "top-level keys"
+assert set(d) == {
+    "DOWNLOAD_WDL_URI",
+    "COMPRESS_WDL_URI",
+    "INDEX_WDL_URI",
+    "STAGES_IO_MAP_JSON",
+    "Input",
+    "OutputPrefix",
+    "DownloadEC2Memory",
+    "CompressEC2Memory",
+    "IndexSPOTMemory",
+    "IndexEC2Memory",
+}, "top-level keys"
 assert d["DOWNLOAD_WDL_URI"].endswith("index-generation-v2.4.8/download.wdl")
 assert d["INDEX_WDL_URI"].endswith("index-generation-v2.4.8/index.wdl")
+
 # per-stage inputs carry ONLY declared keys, NO undeclared keys
-assert d["Input"]["Download"] == {"docker_image_id": "491013321714.dkr.ecr.us-west-2.amazonaws.com/index-generation:v2.4.8"}
-assert d["Input"]["Compress"] == {"docker_image_id": "491013321714.dkr.ecr.us-west-2.amazonaws.com/index-generation:v2.4.8"}
-assert set(d["Input"]["Index"]) == {"docker_image_id","index_name"}, "Index keys (no previous_lineages since none prior)"
+_image = "491013321714.dkr.ecr.us-west-2.amazonaws.com/index-generation:v2.4.8"
+assert d["Input"]["Download"] == {"docker_image_id": _image}
+assert d["Input"]["Compress"] == {"docker_image_id": _image}
+assert set(d["Input"]["Index"]) == {"docker_image_id", "index_name"}, "Index keys"
 assert d["Input"]["Index"]["index_name"] == "2026-07-21"
-for stage in ("Download","Compress","Index"):
-    for bad in ("write_to_db","env","s3_dir"):
+for stage in ("Download", "Compress", "Index"):
+    for bad in ("write_to_db", "env", "s3_dir"):
         assert bad not in d["Input"][stage], f"{bad} leaked into {stage}"
-assert d["DownloadEC2Memory"]==14000 and d["CompressEC2Memory"]==380000 and d["IndexSPOTMemory"]==128000 and d["IndexEC2Memory"]==250000
+assert d["DownloadEC2Memory"] == 14000
+assert d["CompressEC2Memory"] == 380000
+assert d["IndexSPOTMemory"] == 128000
+assert d["IndexEC2Memory"] == 250000
+
 # io-map written to S3 + referenced
 assert captured["put_objects"], "io-map put_object called"
 iomap = json.loads(captured["put_objects"][0]["Body"].decode())
-assert iomap["Compress"]["download_out_nt"]=="nt" and iomap["Index"]["compress_out_taxdump"]=="taxdump"
+assert iomap["Compress"]["download_out_nt"] == "nt"
+assert iomap["Index"]["compress_out_taxdump"] == "taxdump"
 assert d["STAGES_IO_MAP_JSON"].endswith("2026-07-21/stage_io_map.json")
 print("\nALL ASSERTIONS PASSED")

--- a/terraform/start_index_generation_lambda_src/test_main.py
+++ b/terraform/start_index_generation_lambda_src/test_main.py
@@ -1,0 +1,58 @@
+"""Contract test for the multi-stage start_index_generation lambda (CZID-774).
+Verifies the SFN input matches the deployed SWIPE io-helper contract:
+per-stage Input has only declared sub-WDL keys, STAGES_IO_MAP_JSON is emitted,
+and no undeclared keys (write_to_db/env/s3_dir) leak into any stage.
+"""
+import json, os, sys, types
+
+# stub boto3 before importing the handler
+captured = {"sfn_input": None, "put_objects": []}
+
+class FakePaginator:
+    def paginate(self, **kw): return [{"Contents": []}]  # no prior lineages
+class FakeS3:
+    def get_paginator(self, name): return FakePaginator()
+    def put_object(self, **kw): captured["put_objects"].append(kw)
+class FakeSFN:
+    def start_execution(self, **kw): captured["sfn_input"] = json.loads(kw["input"]); captured["exec_name"] = kw["name"]
+
+fake_boto3 = types.ModuleType("boto3")
+fake_boto3.client = lambda svc: FakeSFN() if svc == "stepfunctions" else FakeS3()
+sys.modules["boto3"] = fake_boto3
+
+os.environ.update({
+    "DEPLOYMENT_ENVIRONMENT": "dev",
+    "INDEX_GENERATION_SFN_ARN": "arn:aws:states:us-west-2:491013321714:stateMachine:idseq-swipe-dev-index-generation-wdl",
+    "INDEX_GENERATION_WORKFLOW_VERSION": "v2.4.8",
+    "AWS_REGION": "us-west-2",
+    "AWS_ACCOUNT_ID": "491013321714",
+    "BUCKET": "seqtoid-public-references",
+    "S3_WORKFLOWS_BUCKET": "seqtoid-workflows-dev-491013321714",
+    "DOWNLOAD_MEMORY": "14000", "COMPRESS_MEMORY": "380000",
+    "INDEX_SPOT_MEMORY": "128000", "INDEX_EC2_MEMORY": "250000",
+})
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import main
+main.start_index_generation({"time": "2026-07-21T08:00:00Z"})
+
+d = captured["sfn_input"]
+print(json.dumps(d, indent=2))
+# assertions
+assert set(d) == {"DOWNLOAD_WDL_URI","COMPRESS_WDL_URI","INDEX_WDL_URI","STAGES_IO_MAP_JSON","Input","OutputPrefix","DownloadEC2Memory","CompressEC2Memory","IndexSPOTMemory","IndexEC2Memory"}, "top-level keys"
+assert d["DOWNLOAD_WDL_URI"].endswith("index-generation-v2.4.8/download.wdl")
+assert d["INDEX_WDL_URI"].endswith("index-generation-v2.4.8/index.wdl")
+# per-stage inputs carry ONLY declared keys, NO undeclared keys
+assert d["Input"]["Download"] == {"docker_image_id": "491013321714.dkr.ecr.us-west-2.amazonaws.com/index-generation:v2.4.8"}
+assert d["Input"]["Compress"] == {"docker_image_id": "491013321714.dkr.ecr.us-west-2.amazonaws.com/index-generation:v2.4.8"}
+assert set(d["Input"]["Index"]) == {"docker_image_id","index_name"}, "Index keys (no previous_lineages since none prior)"
+assert d["Input"]["Index"]["index_name"] == "2026-07-21"
+for stage in ("Download","Compress","Index"):
+    for bad in ("write_to_db","env","s3_dir"):
+        assert bad not in d["Input"][stage], f"{bad} leaked into {stage}"
+assert d["DownloadEC2Memory"]==14000 and d["CompressEC2Memory"]==380000 and d["IndexSPOTMemory"]==128000 and d["IndexEC2Memory"]==250000
+# io-map written to S3 + referenced
+assert captured["put_objects"], "io-map put_object called"
+iomap = json.loads(captured["put_objects"][0]["Body"].decode())
+assert iomap["Compress"]["download_out_nt"]=="nt" and iomap["Index"]["compress_out_taxdump"]=="taxdump"
+assert d["STAGES_IO_MAP_JSON"].endswith("2026-07-21/stage_io_map.json")
+print("\nALL ASSERTIONS PASSED")

--- a/terraform/swipe.tf
+++ b/terraform/swipe.tf
@@ -66,6 +66,12 @@ module "swipe" {
         "index_generation_compress_job_queue_arn" : aws_batch_job_queue.index_generation["compress"].arn,
         "index_generation_index_spot_job_queue_arn" : aws_batch_job_queue.index_generation["index_spot"].arn,
         "index_generation_index_on_demand_job_queue_arn" : aws_batch_job_queue.index_generation["index_ondemand"].arn,
+        # Graviton (Lever 2, CZID-776): override the shared amd64 swipe_main job-def with the
+        # dedicated arm64 job-def for index-generation only. swipe-sfn renders the template with
+        # merge({batch_job_definition_name = <swipe_main>...}, extra_template_vars), and merge's
+        # second arg wins, so this replaces batch_job_definition_name for THIS SFN alone. The
+        # arm64 CEs (r7g/m7g) can only exec the arm64 SWIPE runner; short-read-mngs is untouched.
+        "batch_job_definition_name" : aws_batch_job_definition.index_generation_arm64.name,
       },
     },
   }


### PR DESCRIPTION
## Why
The Graviton (arm64) index-generation stack was applied to LIVE dev but never merged, so main's config diverged from what's running (main had scratch=500, the old `ls /dev/sd?` mount, no arm64 job-def, and `use_graviton` defaulting to false while live runs m7g/r7g via a manual TF_VAR). This reconciles main to the live state and fixes the bug that killed the core_nt run.

## What
- **NVMe scratch-mount fix**: the boothook found the scratch volume with `ls /dev/sd?`, which matches nothing on Graviton NVMe -> the 2048GB volume was never mounted -> Download filled the ~256GB root and died at 733GB. Now detects the scratch disk by state via `lsblk`.
- **Persist `use_graviton=true`** as the config default (was only true via an ambient TF_VAR at apply, so any apply could silently revert arm64 -> x86).
- Brings the rest of the applied-live stack onto main: download scratch 2048GB, the dedicated arm64 Batch job-def, per-stage Graviton CEs.
- Took the branch (live truth) over main's unapplied #33 start-lambda reconcile.

## After merge
Scoped apply (LT + CE + queue) from main rebuilds the CEs on m7g/r7g with the lsblk mount, then relaunch core_nt.