### PR TITLE
fix: flip ROOT use_graviton default to true (was reverting index-gen CEs to x86)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,8 @@ variable "app_name" {
 variable "owner" { type = string }
 variable "use_graviton" {
   type        = bool
-  default     = false
-  description = "Run index-generation Batch stages on Graviton3 (arm64). Passthrough to module.idseq; enable only after the arm64 image publish + arm64 AUPR>=0.98 gates pass."
+  default     = true
+  description = "Run index-generation Batch stages on Graviton3 (arm64). Passthrough to module.idseq. Default true: arm64 is the applied state (the index-gen CEs run m7g/r7g); this is the value that reaches the module, so it -- not the module-level default -- is what actually selects the arch. Flip to false to fall back to Track A x86."
 }
 
 terraform {


### PR DESCRIPTION
#43 flipped the module-level `use_graviton` default, but the root `main.tf` passes its own `use_graviton` var into module.idseq -- and that root default was still `false`, overriding the module default. A scoped plan of the index-gen LT/CE rebuild (for the NVMe mount fix) therefore wanted to recreate the CEs on x86 (c6i/r6i) instead of the live m7g/r7g. Caught in plan review before apply. This flips the root default to true so arm64 is the value that actually reaches the module.