### PR TITLE
[ON-HOLD] DESIGN: index-gen fan-out architecture (per-DB DAG + sharding + cadence caching) 800/801/802

### DIFF
--- a/terraform/DESIGN-index-gen-download-split.md
+++ b/terraform/DESIGN-index-gen-download-split.md
@@ -1,0 +1,92 @@
+# Index-generation download split: per-database compute + volume (platform-overhaul #799)
+
+Split the single `download` stage into three concurrent per-database stages so core_nt,
+nr, and the taxonomy files download **at the same time on separate boxes with isolated
+disks**. Fixes the two problems that killed run `index-generation-core-nt-s3-192600`:
+serialized nt-behind-nr, and nr's `nr.fsa` filling the shared scratch so core_nt died
+("Need 269326843136 bytes, only 144753012736 available").
+
+## Why (from the failed run)
+- One `download` stage ran update_blastdb.pl + `blastdbcmd -out <db>.fsa` for core_nt AND
+  nr AND taxonomy on ONE 8-vCPU box, ONE scratch volume.
+- nr ran ~7.4h; core_nt then pended "insufficient resources on 1 node" and, when it did
+  start, failed out-of-disk because nr.fsa had consumed the volume.
+- Splitting per-database: wall-clock drops from `taxonomy + nr + nt` (~15h) to
+  `max(taxonomy, nr, nt)` (~7.5h), and disk exhaustion is impossible (isolated volumes).
+- **Resume already exists**: `swipe.tf` sets `call_cache = true` -> miniwdl S3 call cache
+  (PUT/GET). Once split, nr/nt/taxonomy are independent cached stages, so a re-run after a
+  partial failure skips the succeeded stages and re-runs only the failed one.
+
+## Status: infra foundation BUILT (held); routing is step 2
+This branch (`index-gen-split-nt-nr-download`) implements the compute+volume foundation.
+The SFN/lambda/WDL routing that activates it is specified below and is the completing
+increment -- it **requires a dev apply + one validation index run** (the multi-stage SFN
+cannot be locally test-applied: Rosetta wall, and the io-helper contract is exercised only
+at runtime). Held as a draft PR; nothing applies until deliberately run.
+
+## Step 1 -- DONE here (compute + volume)
+- `terraform/index-generation.tf`: `index_generation_stages_base` gains `download_taxonomy`
+  (512 GB scratch), `download_nt` (1536 GB), `download_nr` (2048 GB) -- each an 8-vCPU box
+  (c6i.2xlarge / m7g.2xlarge) with its OWN gp3 scratch volume. The `for_each` over the stage
+  map auto-generates a launch template + compute environment + queue per entry, so these
+  three get isolated compute + disk for free. The old `download` stage is retained (additive)
+  until step 2 switches routing off it, then it is deleted.
+- `terraform/swipe.tf`: `extra_template_vars` gains
+  `index_generation_download_{taxonomy,nt,nr}_job_queue_arn` so the SFN template can route
+  each branch to its queue.
+
+Volume sizing rationale: nr is the largest (compressed volumes + full nr.fsa) -> 2 TB;
+core_nt smaller -> 1.5 TB; taxonomy (accession2taxid incl prot.FULL ~23.6GB + taxdump) ->
+512 GB. gp3, IO-bound, cheap. Cores can be right-sized after a profiling run if the nr
+`blastdbcmd` extraction (largely single-threaded) is the long pole.
+
+## Step 2 -- SPECIFIED (the routing switch; needs the validation run)
+
+### 2a. Sub-WDLs (split `download.wdl`)
+The Download stage runs a per-stage sub-WDL (`.../index-generation-vX/download.wdl`, the
+per-stage split of the monolith `seqtoid-workflows/.../index-generation.wdl`). Split it into
+three sub-WDLs, each a single-database workflow reusing the existing `DownloadDatabase` /
+`UnzipFile` tasks unchanged:
+- `download-taxonomy.wdl` -- the `scatter (UnzipFile)` over the accession2taxid + taxdump
+  files. Outputs the 5 unzipped taxonomy files.
+- `download-nt.wdl` -- `call DownloadDatabase as DownloadNT { database_type = "nt" }`
+  (core_nt via `update_blastdb.pl --source aws`). Output: `nt.fsa`.
+- `download-nr.wdl` -- `call DownloadDatabase as DownloadNR { database_type = "nr" }`.
+  Output: `nr.fsa`.
+Upload alongside the existing per-stage WDLs (the deploy script's WDL upload step).
+
+### 2b. Lambda (`start_index_generation_lambda_src/main.py`)
+Currently emits `DOWNLOAD_WDL_URI` + `Input.Download` + a `STAGES_IO_MAP` (Download ->
+Compress -> Index). Change to emit:
+- `DOWNLOAD_TAXONOMY_WDL_URI`, `DOWNLOAD_NT_WDL_URI`, `DOWNLOAD_NR_WDL_URI` (+ matching
+  `Input.DownloadTaxonomy/DownloadNT/DownloadNR` payloads, each `{docker_image_id}`).
+- Per-stage memory overrides for the three (reuse the download memory default).
+- `STAGES_IO_MAP`: Compress's `download_out_nt` <- DownloadNT output, `download_out_nr` <-
+  DownloadNR output, taxonomy files <- DownloadTaxonomy outputs (replacing the single
+  Download->Compress handoff). Update `test_main.py` assertions accordingly.
+
+### 2c. SFN template (`terraform/sfn_templates/index-generation.yml`)
+Replace the single `Download` Task (currently `Next: DownloadReadOutput -> DownloadSucceeded
+-> Compress`) with a `Parallel` state, three branches, each mirroring the existing Download
+Task+ReadOutput pattern but pointed at its own queue + WDL URI:
+- branch DownloadTaxonomy -> `${index_generation_download_taxonomy_job_queue_arn}`, WDL
+  `$.DOWNLOAD_TAXONOMY_WDL_URI`
+- branch DownloadNT -> `${index_generation_download_nt_job_queue_arn}`, `$.DOWNLOAD_NT_WDL_URI`
+- branch DownloadNR -> `${index_generation_download_nr_job_queue_arn}`, `$.DOWNLOAD_NR_WDL_URI`
+Each branch keeps the `Retry: *BatchRetryConfig` and a per-branch ReadOutput lambda call.
+The Parallel state's `Catch: [States.ALL] -> HandleFailure`; on success `Next: Compress`.
+AWS Batch runs the three submitJob.sync branches concurrently -> three separate boxes.
+Then remove the retained `download` stage from `index-generation.tf` + its
+`extra_template_vars` arn.
+
+### 2d. Validation run (the gate before merge)
+1. Apply this via CI (dev). 2. Trigger one index-generation run. 3. Confirm three download
+Batch jobs run CONCURRENTLY on three boxes (each its own queue), none out-of-disk, and the
+Compress stage receives nt + nr + taxonomy via the io-map. 4. Kill one branch mid-run and
+re-trigger -> confirm call_cache skips the two succeeded branches (resume proof). Only then
+merge + remove `download`.
+
+## Time impact (why "correct" is also faster)
+Serialized re-run to a completed download ~15h; split ~7.5h (max of the three) + ~3-4h eng
+= ~11-12h. The parallelism saves more than the split costs to build. Compress + Index stages
+are unchanged.

--- a/terraform/DESIGN-index-gen-fanout-architecture.md
+++ b/terraform/DESIGN-index-gen-fanout-architecture.md
@@ -1,0 +1,128 @@
+# Index-generation fan-out architecture: per-DB DAG + sharding + cadence caching
+
+Builds on the download split (#799). Covers levers (2) per-database end-to-end fan-out,
+(3) shard the single-threaded long poles, and (4) decouple refresh cadence via caching.
+Target: build the FULL nt+nr index (the #788 NT-only call is pending and we are NOT betting
+on it) in the shortest wall-clock, and make future refreshes skip unchanged work.
+
+All held. This is a multi-stage SFN + WDL + lambda re-architecture that cannot be locally
+test-applied (Rosetta) and is gated on validation runs. Sequenced so each increment lands on
+a green run before the next.
+
+## The DAG (from index-generation.wdl) -- three independent lanes
+
+Today's SFN is linear: `Download(all) -> Compress(nr) -> Index(all)`. But the task graph is
+three lanes that share NOTHING until final assembly:
+
+```
+TAXONOMY lane:  UnzipFile x5 (accession2taxid nucl_gb/nucl_wgs/pdb/prot.FULL + taxdump)
+                   -> GenerateIndexAccessions (accession2taxid_db)
+                   -> GenerateIndexLineages   (lineage dbs, deuterostome, ignore/changed logs)
+
+NT lane:        DownloadNT -> [CompressNT -> ShuffleNT]?  (compression optional for nt)
+                   -> GenerateNTLocDB
+                   -> GenerateNTInfoDB
+                   -> GenerateIndexMinimap2   (minimap2_index)
+
+NR lane:        DownloadNR -> CompressNR -> ShuffleNR       (the long pole)
+                   -> GenerateNRLocDB
+                   -> GenerateIndexDiamond    (diamond_index; already --scatter-gather chunked)
+
+ASSEMBLE:       collect all lane outputs -> write_to_db / load
+```
+
+Wall-clock today = taxonomy + nt-work + nr-work serialized. Fanned out =
+`max(taxonomy_lane, nt_lane, nr_lane)`. The NR lane (download ~7.4h + compress multi-hour +
+diamond) is the long pole, so lever (3) targets it.
+
+## Lever (2) -- per-database end-to-end fan-out
+
+Restructure the SFN from one linear chain into **three parallel lanes** that run
+concurrently and join once, at assembly. The download split (#799) is lane-step-1; this
+extends the same Parallel-branch pattern through compress + index.
+
+- **SFN template** (`sfn_templates/index-generation.yml`): replace `Download -> Compress ->
+  IndexSPOT` with a top-level `Parallel` of three branches (Taxonomy, NT, NR), each an
+  internal chain of submitJob.sync stages on that lane's queues, then an `Assemble` join
+  stage after the Parallel.
+- **Sub-WDLs**: split the monolith into per-lane WDLs -- `taxonomy.wdl` (unzip + accessions
+  + lineages), `nt.wdl` (download-nt + optional compress + loc/info/minimap2), `nr.wdl`
+  (download-nr + compress + shuffle + loc/diamond). Each reuses the existing tasks unchanged;
+  only the workflow wiring is new. (The #799 download-{nt,nr,taxonomy}.wdl become the first
+  call in each lane WDL.)
+- **Lambda** (`start_index_generation_lambda_src/main.py`): emit per-lane WDL URIs +
+  per-lane Input payloads + a `STAGES_IO_MAP` that threads each lane's outputs into Assemble
+  (instead of the linear Download->Compress->Index handoff). Update `test_main.py`.
+- **Compute**: the #799 per-DB download queues extend to per-lane compute -- each lane's
+  compress/index stages route to their existing right-sized queues (compress = r6i/r7g.12xl
+  on-demand; index = spot with on-demand fallback). Lanes run on separate compute
+  concurrently; dev spot_max_vcpus=4096 has ample headroom.
+
+Expected wall-clock: dominated by the NR lane. NT lane (download ~4-5h + minimap2) and
+taxonomy lane (~3.4h today, cut by #799's own box) finish well inside the NR lane, so they
+become free.
+
+## Lever (3) -- shard the single-threaded long poles (attacks the NR lane)
+
+Within the NR lane the poles are single-threaded, so bigger boxes do not help; sharding does.
+The pre-built BLAST db arrives as multiple volume files (nr.00, nr.01, ...), a natural shard
+boundary, and diamond already scatter-gathers -- so the pattern is in-repo.
+
+- **NR FASTA extraction** (`blastdbcmd -entry all -out nr.fsa`): scatter by volume/OID range
+  -- `blastdbcmd` per shard (`-entry_batch` or per-volume) in parallel, concat the shard
+  fastas. N-way parallel -> ~1/N the extraction time.
+- **CompressNR** (`ncbi-compress`, the other multi-hour single task): shard-then-merge ONLY
+  if clustering correctness is preserved across shards. ncbi-compress dedups/clusters; naive
+  sharding can change which representatives survive. Validate AUPR (>=0.98 gate) on a sharded
+  vs unsharded build before adopting -- if sharding shifts AUPR, keep CompressNR whole and
+  instead right-size its box. (This is the one lever with a correctness risk; gate it hard.)
+- **DiamondIndex**: already chunked (`--scatter-gather -b chunksize`); confirm the chunk
+  count uses the lane's full vCPU.
+
+Sharding is additive to lever (2): each shard is a scatter inside the NR lane WDL, so it
+needs no new SFN stages -- miniwdl fans the scatter across the lane box's cores (or, for
+cross-box scale, promote the shard to its own Batch stage). Start with in-WDL scatter on a
+larger NR box; promote to per-shard Batch stages only if a single box caps out.
+
+## Lever (4) -- decouple refresh cadence via caching (mostly already there)
+
+`call_cache = true` (swipe.tf) already caches every task by an input-hash. Combined with the
+lane fan-out, each lane is an independently cacheable unit: a build whose NR inputs are
+unchanged gets a full NR-lane cache hit and skips it. The work to make this real:
+
+- **Pin taxonomy/lineage inputs** (ties to #778 snapshot-and-hold, #747). Today the taxonomy
+  lane pulls "current" from NCBI FTP, so its input hash changes every run and never caches.
+  Pin to the captured `ncbi-indexes/<date>/` snapshot so an unchanged-lineage build cache-hits
+  the whole taxonomy lane. This is what makes "quarterly lineage, annual nt/nr" real: refresh
+  the pin only when you intend to.
+- **Cadence trigger modes** (start_index_generation lambda): a `refresh_scope` input --
+  `full` (rebuild all), `nt_only`, `nr_only`, `lineage_only` -- that supplies the pinned
+  (cached) inputs for the lanes NOT being refreshed, so call_cache skips them. With the lanes
+  independent (lever 2), this is just "which lane's inputs did we bump."
+- **Result**: an annual nt/nr rebuild reuses cached lineage; a quarterly lineage refresh
+  reuses cached nt/nr; a core_nt-vs-full-nt A/B (#770) reuses the shared taxonomy lane for
+  both arms. No monolith rebuild each time.
+
+## How the levers compose
+
+(2) makes each DB an independent, cacheable lane. (3) collapses the NR lane's long pole so
+the fanned-out wall-clock keeps dropping. (4) makes unchanged lanes free on subsequent builds
+and enables concurrent A/B builds. Net: first full build ~= NR-lane wall-clock (down from
+serialized ~15h+ just for download); later scoped refreshes skip whole lanes.
+
+## Sequencing (each gated on a green validation run)
+
+1. **#799 download split** (built, held) -- validate: 3 concurrent download boxes, no OOD.
+2. **Lever (2) fan-out** -- extend Parallel through compress+index; per-lane sub-WDLs +
+   lambda IO-map + Assemble join. Validate: 3 lanes run concurrently, outputs assemble, AUPR
+   >= 0.98 unchanged vs a linear build.
+3. **Lever (3) NR sharding** -- FASTA-extract scatter first (no correctness risk), then
+   CompressNR sharding ONLY if AUPR holds. Validate AUPR each step.
+4. **Lever (4) cadence** -- pin taxonomy snapshot + refresh_scope modes. Validate: an
+   nt_only refresh cache-hits the nr + lineage lanes.
+
+## Non-negotiables
+
+- FULL nt+nr (do not drop NR; #788 pending, assume both needed).
+- AUPR >= 0.98 gate on every build that changes indexing/sharding/compression.
+- Dev-only; apply via CI (Rosetta wall); nothing merges without its validation run.

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -37,6 +37,54 @@ locals {
   #   compress   r6i.12xlarge (48/384)          -> r7g.12xlarge (48/384)
   #   index      r6i.{4,8,12}xlarge (16..48 / 128..384) -> r7g.{4,8,12}xlarge (same)
   index_generation_stages_base = {
+    # DOWNLOAD SPLIT (platform-overhaul 799). The old single `download` stage ran
+    # update_blastdb.pl + blastdbcmd -out <db>.fsa for core_nt AND full nr AND the taxonomy
+    # files on ONE 8-vCPU box sharing ONE scratch volume. That serialized nt behind nr (nr ran
+    # ~7.4h, nt then pended "insufficient resources on 1 node") and, worse, nr's nr.fsa filled
+    # the shared volume so core_nt failed with "Need 269326843136 bytes, only 144753012736
+    # available" (run index-generation-core-nt-s3-192600). Splitting into three per-DATABASE
+    # stages -- each its own compute environment + queue (the for_each below) and its OWN
+    # right-sized scratch volume -- lets nt, nr and taxonomy download CONCURRENTLY on separate
+    # boxes with isolated disks. Download wall-clock collapses from (taxonomy + nr + nt) to
+    # max(taxonomy, nr, nt). Per-DB failure is also isolated: with call_cache=true (swipe.tf)
+    # a re-run skips the succeeded DB stages and re-runs only the failed one.
+    #
+    # These SUPERSEDE the single `download` stage. `download` is retained (below) until the
+    # SFN template + start_index_generation lambda routing switch lands (799 step 2, see
+    # deploy/../DESIGN or the ticket); at that point `download` is removed. Additive for now so
+    # nothing that still references the `download` queue breaks.
+    #
+    # Same 8-vCPU box as the proven single-stage download; only scratch differs, sized to each
+    # DB's working set (compressed volumes + uncompressed .fsa) with headroom. gp3 is cheap and
+    # the stage is IO-bound. Right-size cores after a profiling run if nr extraction is the long
+    # pole (matches this file's "confirm against one profiling run" ethos).
+    download_taxonomy = {
+      instance_types_x86      = ["c6i.2xlarge"] # 8 vCPU / 16 GB
+      instance_types_graviton = ["m7g.2xlarge"] # 8 vCPU / 32 GB (Graviton3)
+      max_vcpus               = 8
+      # accession2taxid (nucl_gb/nucl_wgs/pdb/prot.FULL ~23.6GB compressed) + taxdump; the
+      # decompressed working set is the long pole here (prot.FULL). 512 GB is ample.
+      scratch_gb   = 512
+      provisioning = "EC2"
+    }
+    download_nt = {
+      instance_types_x86      = ["c6i.2xlarge"]
+      instance_types_graviton = ["m7g.2xlarge"]
+      max_vcpus               = 8
+      # core_nt: compressed BLAST volumes (~269 GB) + core_nt.fsa. 1.5 TB isolated volume.
+      scratch_gb   = 1536
+      provisioning = "EC2"
+    }
+    download_nr = {
+      instance_types_x86      = ["c6i.2xlarge"]
+      instance_types_graviton = ["m7g.2xlarge"]
+      max_vcpus               = 8
+      # nr is the largest: compressed volumes + full nr.fsa. 2 TB isolated volume (was the DB
+      # that exhausted the shared 500 GB / left only 134.8 GiB for core_nt).
+      scratch_gb   = 2048
+      provisioning = "EC2"
+    }
+    # RETAINED until the routing switch (799 step 2) moves the SFN off it, then delete.
     download = {
       instance_types_x86      = ["c6i.2xlarge"] # 8 vCPU / 16 GB
       instance_types_graviton = ["m7g.2xlarge"] # 8 vCPU / 32 GB (Graviton3)

--- a/terraform/swipe.tf
+++ b/terraform/swipe.tf
@@ -63,6 +63,13 @@ module "swipe" {
       # to the on-demand queue on a spot reclaim (see sfn_templates/index-generation.yml).
       extra_template_vars = {
         "index_generation_download_job_queue_arn" : aws_batch_job_queue.index_generation["download"].arn,
+        # Download split (799): per-database queues so nt/nr/taxonomy run concurrently on
+        # separate right-sized boxes. Wired here so the SFN template's Parallel Download
+        # branches can route to them (routing switch is 799 step 2). Additive: the single
+        # `download` arn above stays until that switch removes it.
+        "index_generation_download_taxonomy_job_queue_arn" : aws_batch_job_queue.index_generation["download_taxonomy"].arn,
+        "index_generation_download_nt_job_queue_arn" : aws_batch_job_queue.index_generation["download_nt"].arn,
+        "index_generation_download_nr_job_queue_arn" : aws_batch_job_queue.index_generation["download_nr"].arn,
         "index_generation_compress_job_queue_arn" : aws_batch_job_queue.index_generation["compress"].arn,
         "index_generation_index_spot_job_queue_arn" : aws_batch_job_queue.index_generation["index_spot"].arn,
         "index_generation_index_on_demand_job_queue_arn" : aws_batch_job_queue.index_generation["index_ondemand"].arn,


### PR DESCRIPTION
**DESIGN / HELD.** Fan-out architecture for index-generation -- levers 2/3/4 on top of the #799 download split. Builds the FULL nt+nr index (not betting on the pending #788 NT-only call). platform-overhaul #800 (lever 2), #801 (lever 3), #802 (lever 4).

Grounded in the actual `index-generation.wdl` DAG: three lanes (taxonomy/lineage, NT, NR) that share nothing until final assembly. Today's SFN serializes them; the design fans them into concurrent lanes.

- **Lever 2 (#800)** -- SFN `Download->Compress->Index` becomes a `Parallel` of 3 lane branches -> `Assemble`. Per-lane sub-WDLs + lambda IO-map. Wall-clock -> max(lane), NR dominates; NT + taxonomy become free.
- **Lever 3 (#801)** -- shard the NR single-threaded poles (blastdbcmd FASTA extract by volume = no risk; CompressNR shard-then-merge ONLY if AUPR>=0.98 holds). Diamond already scatter-gathers.
- **Lever 4 (#802)** -- pin taxonomy/lineage snapshot (#778/#747) + `refresh_scope` modes so call_cache (already on) skips unchanged lanes: quarterly-lineage / annual-nt+nr / concurrent A/B without a monolith rebuild.

Sequenced so each lever lands on a green validation run (AUPR gate on any indexing change). This is a design doc -- the implementation is coupled SFN/WDL/lambda work that can't be test-applied locally (Rosetta) and is gated on dev validation runs. Not merging.
