### PR TITLE
index-gen lever4: taxonomy snapshot pin + refresh_scope in start lambda

### DIFF
--- a/terraform/DESIGN-index-gen-lever4-cadence.md
+++ b/terraform/DESIGN-index-gen-lever4-cadence.md
@@ -1,0 +1,50 @@
+# Lever 4 cadence -- taxonomy snapshot pin + refresh_scope (platform-overhaul #802)
+
+Companion to the fan-out (Lever 2). What is IMPLEMENTED in this branch, and the one residual
+that is deploy-gated.
+
+## Implemented (start_index_generation_lambda_src/main.py + tests)
+
+### 1. Taxonomy snapshot pin (#778/#747)
+NCBI FTP only serves the CURRENT taxonomy, so a rebuild that reads live NCBI is not
+reproducible. New event override `index_generation.taxonomy_snapshot_prefix` (an S3 key
+prefix under the references bucket, or a full `s3://` URI) repoints the taxonomy lane at a
+held snapshot: the lambda passes the five sources (`nucl_gb`, `nucl_wgs`, `pdb`,
+`prot.FULL`, `taxdump`) to the `download-taxonomy` sub-WDL, which already accepts each as an
+overridable URI. Unset => live NCBI (unchanged default).
+
+Operational companion (not code): stage the snapshot once with the same `.gz` filenames, e.g.
+`s3://seqtoid-public-references/ncbi-indexes-dev/taxonomy-snapshots/<date>/`. That is the
+"snapshot-and-hold" pin; the code consumes it.
+
+### 2. refresh_scope (full / nt_only / nr_only / lineage_only)
+New override `index_generation.refresh_scope` (default `full`). An out-of-scope DB lane
+reuses the prior run's compressed fasta (`provided_*` = prior `*_compressed.fa`) and skips
+(re)compression (`skip_*_compression = true`), so a scoped refresh pays neither the download
+nor the compress pole for a DB it is not refreshing. `full` is unchanged (still seeds the
+incremental compress from the prior compressed as before). Invalid values are rejected. An
+explicit `provided_*` / `skip_*` override always wins over the scope default. If no prior
+compressed artifact exists, the lane falls back to a full build (correct, just not skipped).
+
+Covered by `test_main_lever4.py` (no AWS): per-mode input mapping, snapshot pin (prefix and
+full-URI forms), explicit-override precedence, invalid-scope rejection.
+
+## Residual (DEPLOY-GATED follow-on, NOT built)
+
+refresh_scope today still *runs* the out-of-scope lane's index step (it rebuilds the index
+from the reused, unchanged compressed fasta) so the artifact set stays complete. To truly
+"skip whole lanes" -- not schedule the Batch job at all and reuse the prior INDEX directory
+(minimap2 / diamond / loc / info) -- requires:
+
+- SFN template: wrap each Phase-2 lane's `StartAt` in a `Choice` on a per-lane
+  `<Lane>InScope` boolean; the false arm is a `Pass` that publishes the prior run's index
+  output URIs as that lane's Result.
+- io-helper: pre-seed the accumulated Result with those prior output URIs so `MergeLanes` /
+  `Assemble` resolve them by bare name (the DAG handoff map is unchanged).
+- register: `alignment_config_register` already derives every path from the version dir and
+  `head_object`-validates each artifact exists; a scoped build must copy or hardlink the
+  reused prior index artifacts into the new dated prefix so the new AlignmentConfig is
+  self-contained (immutability -- never repoint a config at another version's dir).
+
+This cannot be validated locally (Rosetta wall) and touches the not-yet-deployed fan-out, so
+it is held until the fan-out is deployed + the full-scope validation run is green.

--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -98,10 +98,32 @@ def start_index_generation(event, *args):
     #                                 resume; e.g. the recovered 530GB nr.fsa).
     #   nt_database_type           -- "nt" (default) or "core_nt".
     #   skip_protein_compression / skip_nuc_compression -- pass through to the compress lanes.
+    #   refresh_scope              -- Lever 4 (802): "full" (default) / "nt_only" / "nr_only" /
+    #                                 "lineage_only". A scoped refresh reuses the prior run's
+    #                                 compressed artifact for each out-of-scope DB (skip download
+    #                                 + skip compression) instead of rebuilding it, so it does not
+    #                                 pay the two biggest poles for a DB that did not change.
+    #   taxonomy_snapshot_prefix   -- Lever 4 (802): pin the taxonomy lane to an S3 snapshot
+    #                                 (778/747) instead of live NCBI FTP, which only serves the
+    #                                 CURRENT taxonomy -- required for a reproducible rebuild.
     overrides = event.get("index_generation", {}) if isinstance(event, dict) else {}
     provided_nr = overrides.get("provided_nr")
     provided_nt = overrides.get("provided_nt")
     nt_database_type = overrides.get("nt_database_type", "nt")
+
+    # Lever 4 (802) refresh_scope: which lanes do real work this run.
+    refresh_scope = overrides.get("refresh_scope", "full")
+    valid_scopes = ("full", "nt_only", "nr_only", "lineage_only")
+    if refresh_scope not in valid_scopes:
+        raise ValueError(
+            f"refresh_scope must be one of {valid_scopes}, got {refresh_scope!r}"
+        )
+    nt_in_scope = refresh_scope in ("full", "nt_only")
+    nr_in_scope = refresh_scope in ("full", "nr_only")
+
+    # Lever 4 (802) taxonomy snapshot pin: an S3 key prefix (or full s3:// URI) holding a
+    # held taxonomy snapshot. When unset the taxonomy lane defaults to live NCBI FTP.
+    taxonomy_snapshot_prefix = overrides.get("taxonomy_snapshot_prefix")
 
     sfn = boto3.client("stepfunctions")
     s3 = boto3.client("s3")
@@ -146,8 +168,30 @@ def start_index_generation(event, *args):
     stage_io_map_key = f"ncbi-indexes-{deployment_environment}/{index_name}/stage_io_map.json"
     s3.put_object(Bucket=bucket, Key=stage_io_map_key, Body=json.dumps(STAGES_IO_MAP).encode())
 
+    def snapshot_uri(name):
+        """Resolve a taxonomy snapshot file: `taxonomy_snapshot_prefix` may be a full s3://
+        URI or a key prefix under the references bucket."""
+        prefix = taxonomy_snapshot_prefix.rstrip("/")
+        if prefix.startswith("s3://"):
+            return f"{prefix}/{name}"
+        return s3_uri(f"{prefix}/{name}")
+
     # Per-stage inputs: ONLY each sub-WDL's declared workflow inputs. The File hand-offs are
     # injected at runtime via STAGES_IO_MAP, so they are omitted here.
+    download_taxonomy_input = {"docker_image_id": docker_image_id}
+    if taxonomy_snapshot_prefix:
+        # Lever 4 (802) taxonomy snapshot pin (778/747): NCBI FTP only serves the CURRENT
+        # taxonomy, so a reproducible rebuild must read a held snapshot from S3. The
+        # download-taxonomy sub-WDL already accepts each source as an overridable URI; point the
+        # five at the pinned snapshot (same .gz filenames the WDL's gz-detection expects).
+        download_taxonomy_input.update({
+            "provided_accession2taxid_nucl_gb": snapshot_uri("nucl_gb.accession2taxid.gz"),
+            "provided_accession2taxid_nucl_wgs": snapshot_uri("nucl_wgs.accession2taxid.gz"),
+            "provided_accession2taxid_pdb": snapshot_uri("pdb.accession2taxid.gz"),
+            "provided_accession2taxid_prot": snapshot_uri("prot.accession2taxid.FULL.gz"),
+            "provided_taxdump": snapshot_uri("taxdump.tar.gz"),
+        })
+
     download_nt_input = {"docker_image_id": docker_image_id, "nt_database_type": nt_database_type}
     if provided_nt:
         download_nt_input["provided_nt"] = provided_nt
@@ -159,12 +203,29 @@ def start_index_generation(event, *args):
     compress_nt_input = {"docker_image_id": docker_image_id}
     if previous_nt_compressed:
         compress_nt_input["previous_nt_compressed"] = s3_uri(previous_nt_compressed)
-    if "skip_nuc_compression" in overrides:
-        compress_nt_input["skip_nuc_compression"] = overrides["skip_nuc_compression"]
 
     compress_nr_input = {"docker_image_id": docker_image_id}
     if previous_nr_compressed:
         compress_nr_input["previous_nr_compressed"] = s3_uri(previous_nr_compressed)
+
+    # Lever 4 (802) refresh_scope: an out-of-scope DB lane reuses the prior run's compressed
+    # fasta and skips (re)compression, so a scoped refresh pays neither the download nor the
+    # compress pole for a DB that is not being refreshed. The index step still rebuilds from the
+    # reused fasta, so the artifact set stays complete. Eliminating that index rebuild too (and
+    # reusing the prior index directory) is the deploy-gated SFN Choice-gate follow-on
+    # (DESIGN-index-gen-lever4-cadence.md). If no prior compressed artifact exists, the lane
+    # falls back to a full build (correct, just not skipped). An explicit provided_*/skip
+    # override always wins over the scope default.
+    if not nt_in_scope and not provided_nt and previous_nt_compressed:
+        download_nt_input["provided_nt"] = s3_uri(previous_nt_compressed)
+        compress_nt_input["skip_nuc_compression"] = True
+    if not nr_in_scope and not provided_nr and previous_nr_compressed:
+        download_nr_input["provided_nr"] = s3_uri(previous_nr_compressed)
+        compress_nr_input["skip_protein_compression"] = True
+
+    # Explicit compression-skip overrides take precedence over the refresh_scope default.
+    if "skip_nuc_compression" in overrides:
+        compress_nt_input["skip_nuc_compression"] = overrides["skip_nuc_compression"]
     if "skip_protein_compression" in overrides:
         compress_nr_input["skip_protein_compression"] = overrides["skip_protein_compression"]
 
@@ -173,7 +234,7 @@ def start_index_generation(event, *args):
         index_taxonomy_input["previous_lineages"] = s3_uri(previous_lineages)
 
     stage_inputs = {
-        "DownloadTaxonomy": {"docker_image_id": docker_image_id},
+        "DownloadTaxonomy": download_taxonomy_input,
         "DownloadNT": download_nt_input,
         "DownloadNR": download_nr_input,
         "CompressNT": compress_nt_input,

--- a/terraform/start_index_generation_lambda_src/test_main_lever4.py
+++ b/terraform/start_index_generation_lambda_src/test_main_lever4.py
@@ -1,0 +1,129 @@
+"""Lever 4 (802) tests for start_index_generation: refresh_scope + taxonomy snapshot pin.
+
+Stubs S3 to expose a prior run's compressed artifacts so the scoped-refresh reuse path is
+exercised, then checks the per-stage Inputs the lambda builds for each mode. No AWS.
+"""
+import json
+import os
+import sys
+import types
+
+captured = {"sfn_input": None, "put_objects": []}
+
+_PRIOR = "ncbi-indexes-dev/2026-07-09/index-generation-2"
+_PRIOR_KEYS = [
+    f"{_PRIOR}/nt_compressed.fa",
+    f"{_PRIOR}/nr_compressed.fa",
+    f"{_PRIOR}/versioned-taxid-lineages.csv.gz",
+]
+
+
+class FakePaginator:
+    def paginate(self, **kw):
+        return [{"Contents": [{"Key": k} for k in _PRIOR_KEYS]}]
+
+
+class FakeS3:
+    def get_paginator(self, name):
+        return FakePaginator()
+
+    def put_object(self, **kw):
+        captured["put_objects"].append(kw)
+
+
+class FakeSFN:
+    def start_execution(self, **kw):
+        captured["sfn_input"] = json.loads(kw["input"])
+
+
+fake_boto3 = types.ModuleType("boto3")
+fake_boto3.client = lambda svc: FakeSFN() if svc == "stepfunctions" else FakeS3()
+sys.modules["boto3"] = fake_boto3
+
+os.environ.update({
+    "DEPLOYMENT_ENVIRONMENT": "dev",
+    "INDEX_GENERATION_SFN_ARN":
+        "arn:aws:states:us-west-2:491013321714:stateMachine:idseq-swipe-dev-index-generation-wdl",
+    "INDEX_GENERATION_WORKFLOW_VERSION": "v2.4.8",
+    "AWS_REGION": "us-west-2",
+    "AWS_ACCOUNT_ID": "491013321714",
+    "BUCKET": "seqtoid-public-references",
+    "S3_WORKFLOWS_BUCKET": "seqtoid-workflows-dev-491013321714",
+    "DOWNLOAD_MEMORY": "14000",
+    "COMPRESS_MEMORY": "380000",
+    "INDEX_SPOT_MEMORY": "128000",
+    "INDEX_EC2_MEMORY": "250000",
+})
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import main  # noqa: E402
+
+_BASE = "s3://seqtoid-public-references"
+_PRIOR_NT = f"{_BASE}/{_PRIOR}/nt_compressed.fa"
+_PRIOR_NR = f"{_BASE}/{_PRIOR}/nr_compressed.fa"
+
+
+def run(scope=None, extra=None):
+    ig = {}
+    if scope:
+        ig["refresh_scope"] = scope
+    if extra:
+        ig.update(extra)
+    captured["sfn_input"] = None
+    main.start_index_generation({"time": "2026-07-23T08:00:00Z", "index_generation": ig})
+    return captured["sfn_input"]["Input"]
+
+
+# ---- full (default): priors seed incremental compression, NO scope-driven reuse skip ----
+inp = run("full")
+assert "provided_nt" not in inp["DownloadNT"], "full: NT must download, not reuse"
+assert "provided_nr" not in inp["DownloadNR"], "full: NR must download, not reuse"
+assert "skip_nuc_compression" not in inp["CompressNT"]
+assert "skip_protein_compression" not in inp["CompressNR"]
+assert inp["CompressNT"]["previous_nt_compressed"] == _PRIOR_NT, "full: still seeds incremental"
+assert inp["CompressNR"]["previous_nr_compressed"] == _PRIOR_NR
+
+# ---- nt_only: NT builds fully; NR reuses prior + skips compression ----
+inp = run("nt_only")
+assert "provided_nt" not in inp["DownloadNT"], "nt_only: NT in scope, full build"
+assert "skip_nuc_compression" not in inp["CompressNT"]
+assert inp["DownloadNR"]["provided_nr"] == _PRIOR_NR, "nt_only: NR reuses prior compressed"
+assert inp["CompressNR"]["skip_protein_compression"] is True
+
+# ---- nr_only: mirror image ----
+inp = run("nr_only")
+assert "provided_nr" not in inp["DownloadNR"]
+assert "skip_protein_compression" not in inp["CompressNR"]
+assert inp["DownloadNT"]["provided_nt"] == _PRIOR_NT
+assert inp["CompressNT"]["skip_nuc_compression"] is True
+
+# ---- lineage_only: both DB lanes reuse prior + skip; taxonomy rebuilds ----
+inp = run("lineage_only")
+assert inp["DownloadNT"]["provided_nt"] == _PRIOR_NT
+assert inp["DownloadNR"]["provided_nr"] == _PRIOR_NR
+assert inp["CompressNT"]["skip_nuc_compression"] is True
+assert inp["CompressNR"]["skip_protein_compression"] is True
+
+# ---- taxonomy snapshot pin: five sources point at the snapshot, not NCBI ----
+inp = run("full", {"taxonomy_snapshot_prefix": "ncbi-indexes-dev/taxonomy-snapshots/2026-07-09"})
+dt = inp["DownloadTaxonomy"]
+snap = f"{_BASE}/ncbi-indexes-dev/taxonomy-snapshots/2026-07-09"
+assert dt["provided_taxdump"] == f"{snap}/taxdump.tar.gz"
+assert dt["provided_accession2taxid_prot"] == f"{snap}/prot.accession2taxid.FULL.gz"
+assert dt["provided_accession2taxid_nucl_gb"] == f"{snap}/nucl_gb.accession2taxid.gz"
+
+# ---- snapshot prefix given as a full s3:// URI ----
+inp = run("full", {"taxonomy_snapshot_prefix": "s3://other-bucket/snap/2026-07-09/"})
+assert inp["DownloadTaxonomy"]["provided_taxdump"] == "s3://other-bucket/snap/2026-07-09/taxdump.tar.gz"
+
+# ---- explicit skip override wins over scope default ----
+inp = run("nr_only", {"skip_nuc_compression": False})
+assert inp["CompressNT"]["skip_nuc_compression"] is False, "explicit override must win"
+
+# ---- invalid scope rejected ----
+try:
+    run("nt_and_nr")
+    raise SystemExit("FAIL: invalid refresh_scope was accepted")
+except ValueError as e:
+    assert "refresh_scope must be one of" in str(e)
+
+print("ALL LEVER-4 ASSERTIONS PASSED")


### PR DESCRIPTION
Lever 4 cadence controls on top of the Lever 2 fan-out start lambda.

**Taxonomy snapshot pin.** NCBI FTP only serves the current taxonomy, so a rebuild that reads live NCBI is not reproducible. New event override `taxonomy_snapshot_prefix` (an S3 key prefix under the references bucket, or a full s3:// URI) repoints the taxonomy lane at a held snapshot: the lambda passes the five accession2taxid/taxdump .gz sources to the download-taxonomy sub-WDL, which already accepts each as an overridable URI. Unset keeps the live-NCBI default. Staging the snapshot itself is the operational companion (same .gz filenames).

**refresh_scope (full / nt_only / nr_only / lineage_only, default full).** An out-of-scope DB lane reuses the prior run's compressed fasta and skips (re)compression, so a scoped refresh pays neither the download nor the compress pole for a DB it is not refreshing. `full` is unchanged. Explicit provided_*/skip_* overrides win over the scope default; invalid scopes are rejected; no prior artifact falls back to a full build.

No SFN-contract change -- effects are confined to per-stage Inputs, so the io-helper contract and top-level SFN input shape are unchanged and the existing contract test stays green. Adds test_main_lever4.py (no AWS) covering each mode, the snapshot pin, override precedence, and invalid-scope rejection.

Truly eliminating the out-of-scope Batch jobs and reusing the prior index directory is the deploy-gated follow-on documented in DESIGN-index-gen-lever4-cadence.md.

Tests: `python3 test_main.py` and `python3 test_main_lever4.py` both pass.