### PR TITLE
targeted-apply: plan with -lock=false (read-only role can't write lockfile)

### DIFF
--- a/.github/workflows/targeted-apply.yml
+++ b/.github/workflows/targeted-apply.yml
@@ -112,7 +112,12 @@ jobs:
           targs=()
           for t in "${_targets[@]}"; do targs+=("-target=$t"); done
           echo "terraform plan ${targs[*]}"
-          terraform plan -input=false "${targs[@]}" -out=tf.plan | tee plan.txt
+          # -lock=false: the plan job assumes the READ-ONLY czid-<env>-gh-actions-plan role,
+          # which has no s3:PutObject, so it cannot write the backend state lockfile
+          # (use_lockfile = true). A read-only plan never mutates state, so skipping the lock
+          # is safe -- it still reads + refreshes current state. The gated apply job (write role)
+          # keeps the default lock.
+          terraform plan -input=false -lock=false "${targs[@]}" -out=tf.plan | tee plan.txt
           {
             echo "### Scoped plan for \`$TARGETS\`"
             echo '```'


### PR DESCRIPTION
The scoped-plan job uses the read-only czid-<env>-gh-actions-plan role (no s3:PutObject). With use_lockfile = true on the S3 backend, terraform plan tries to write the state lockfile and gets 403 AccessDenied -- so the plan never renders (observed on run 30009620268; the job reported success while the plan step errored on the lock). A read-only plan never mutates state, so -lock=false is safe (still reads + refreshes). The gated apply job keeps the default lock. Unblocks the index-gen fan-out plan render.