### PR TITLE
targeted-apply: regenerate fetched-module archive_file zips before apply

### DIFF
--- a/.github/workflows/targeted-apply.yml
+++ b/.github/workflows/targeted-apply.yml
@@ -198,5 +198,16 @@ jobs:
             echo "::error::No tf.plan found from the plan job."
             exit 1
           fi
+          # Regenerate archive_file outputs that live INSIDE fetched modules (e.g. the swipe
+          # sfn-io-helper deployment.zip). `make package-lambdas` above only builds the
+          # root-repo lambda zips; a module's archive_file zip is written by terraform at plan
+          # time and does NOT travel in tf.plan across the plan->apply job boundary, so the
+          # saved plan would fail with "reading ZIP file ... deployment.zip: no such file".
+          # A throwaway scoped re-plan re-evaluates those archive_file data sources and writes
+          # the zips to disk byte-identically (same source => same output_sha), so the saved
+          # plan still applies (and is still rejected if real state drifted).
+          read -ra _t <<< "$TARGETS"; ta=(); for t in "${_t[@]}"; do ta+=("-target=$t"); done
+          terraform plan -input=false -lock=false "${ta[@]}" -out=regen.tfplan >/dev/null 2>&1 || true
+          rm -f regen.tfplan
           echo "Applying the reviewed scoped plan. Terraform refuses it if state drifted since planning."
           terraform apply -input=false tf.plan


### PR DESCRIPTION
The split plan/apply jobs broke on the swipe sfn-io-helper deployment.zip: archive_file writes it at plan time inside the fetched module, and it does not travel in tf.plan to the apply job (make package-lambdas only builds root-repo zips). The saved-plan apply failed 'reading ZIP file ... deployment.zip: no such file'. Fix: a throwaway scoped re-plan in the apply job regenerates those module archive outputs byte-identically before applying the saved plan. Observed on run 30010181243 (the 3 per-DB queues applied; the io-helper lambdas failed). Idempotent re-run completes the fan-out.