### PR TITLE
start_index_generation: grant s3:PutObject on ncbi-indexes prefix

### DIFF
--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -414,6 +414,17 @@ resource "aws_iam_role_policy" "start_index_generation_lambda" {
         Resource : "arn:aws:s3:::seqtoid-public-references", # TODO: aws_s3_bucket.cypherid-public-references[0].arn
       },
       {
+        # The fan-out lambda writes stage_io_map.json into the run's output prefix (and may
+        # read prior-run artifacts for seeding). Scoped to the ncbi-indexes-<env> prefix so the
+        # lambda cannot touch the rest of the references bucket (~4.8 TB of research data).
+        Effect : "Allow",
+        Action : [
+          "s3:GetObject",
+          "s3:PutObject",
+        ],
+        Resource : "arn:aws:s3:::seqtoid-public-references/ncbi-indexes-${var.DEPLOYMENT_ENVIRONMENT}/*",
+      },
+      {
         Effect : "Allow",
         Action : [
           "logs:CreateLogGroup",


### PR DESCRIPTION
The fan-out start lambda writes stage_io_map.json into ncbi-indexes-<env>/<date>/ but its role only had s3:ListBucket, so the first run invoke failed AccessDenied on PutObject. Adds s3:GetObject + s3:PutObject scoped to the ncbi-indexes-<env> prefix (least-privilege, not the whole references bucket). Unblocks the core_nt fan-out run.