### PR TITLE
chaos: dev-chaos disposable pipeline-sandbox environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ cython_debug/
 
 # .python-version is committed as the Python SSOT (read by check.yml) — CZID-142
 .terraform.dev
+.terraform.dev-chaos
 .terraform.prod
 .terraform.sandbox
 .terraform.staging

--- a/environment
+++ b/environment
@@ -46,7 +46,11 @@ else
     TF_VAR_owner="${OWNER}"
     TF_VAR_environment="${DEPLOYMENT_ENVIRONMENT}"
 
-    if [[ $DEPLOYMENT_ENVIRONMENT == dev || $DEPLOYMENT_ENVIRONMENT == sandbox ]]; then
+    # dev-chaos (the disposable Chaos Engine pipeline sandbox) lives in the dev account and
+    # keeps its state in the same -test tfstate bucket as dev/sandbox, but under its own key
+    # (idseqdev-chaos), so it is fully isolated from dev state while never reaching for the
+    # prod-style tfstate-<acct> bucket that does not exist in the dev account.
+    if [[ $DEPLOYMENT_ENVIRONMENT == dev || $DEPLOYMENT_ENVIRONMENT == sandbox || $DEPLOYMENT_ENVIRONMENT == dev-chaos ]]; then
         TF_S3_BUCKET=tfstate-$AWS_ACCOUNT_ID-test
     else
         TF_S3_BUCKET=tfstate-$AWS_ACCOUNT_ID

--- a/environment.dev-chaos
+++ b/environment.dev-chaos
@@ -1,0 +1,20 @@
+# Resolve the location of this file and set APP_HOME to the root
+if [[ -n "$ZSH_VERSION" ]]; then
+    export APP_HOME=${0:A:h}
+else
+    SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+    export APP_HOME="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+fi
+
+# dev-chaos: the disposable Chaos Engine pipeline sandbox (platform-overhaul roadmap
+# item for the pipeline-chaos sandbox). It is a full, independently-named copy of the
+# dev pipeline -- idseq-dev-chaos-* SFN / Batch / Lambda / buckets -- standing in the
+# SAME dev AWS account (seqtoid-dev, 491013321714) but on its OWN terraform state key
+# (idseqdev-chaos, distinct from dev's idseqdev). The env name has no value validation
+# in the terraform, so this is a variable flip, not a clone: every resource is scoped by
+# ${var.DEPLOYMENT_ENVIRONMENT}, so a dev-chaos apply can NEVER touch a shared idseq-dev-*
+# resource. Chaos experiments fault only this copy; terraform destroy removes it.
+export DEPLOYMENT_ENVIRONMENT=dev-chaos
+export EXPECT_AWS_ACCOUNT_ALIAS=seqtoid-dev
+source "${APP_HOME}/environment"

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,15 @@ variable "use_graviton" {
   description = "Run index-generation Batch stages on Graviton3 (arm64). Passthrough to module.idseq. Default true: arm64 is the applied state (the index-gen CEs run m7g/r7g); this is the value that reaches the module, so it -- not the module-level default -- is what actually selects the arch. Flip to false to fall back to Track A x86."
 }
 
+locals {
+  # Chaos Engine sandbox marker. Applied ONLY when this is the dev-chaos environment, so
+  # every resource in the disposable pipeline copy carries seqtoid.io/chaos-sandbox=true.
+  # The pipeline chaos experiments (P1-P6) refuse any fault target that does not carry this
+  # tag -- the structural guarantee that a chaos fault can only ever hit the sandbox, never
+  # the shared dev pipeline. For all other envs this is {}, so their plans are unchanged.
+  chaos_sandbox_tags = var.environment == "dev-chaos" ? { "seqtoid.io/chaos-sandbox" = "true" } : {}
+}
+
 terraform {
   # required_version + required_providers live in versions.tf (CZID-169 SSOT).
   backend "s3" {
@@ -24,7 +33,7 @@ terraform {
 provider "aws" {
   region = "us-west-2"
   default_tags {
-    tags = {
+    tags = merge({
       environment = var.environment
       env         = var.environment
       owner       = var.owner
@@ -32,7 +41,7 @@ provider "aws" {
       application = var.app_name
       managedBy   = "terraform"
       service     = "main"
-    }
+    }, local.chaos_sandbox_tags)
   }
   ignore_tags {
     key_prefixes = ["QSConfigId-", "QSConfigName-"]

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -52,7 +52,10 @@ locals {
 
   # DATA-1 (CZID-31): allow terraform to destroy data resources only in throwaway envs;
   # protect the shared/long-lived envs (staging/prod) from a silent destroy/replace data loss.
-  data_force_destroy = contains(["dev", "sandbox"], var.DEPLOYMENT_ENVIRONMENT)
+  # dev-chaos is the most throwaway of all -- the Chaos Engine sandbox is meant to be stood up
+  # and torn down between campaigns -- so it is force-destroyable so terraform destroy leaves no
+  # orphaned (billed) buckets behind.
+  data_force_destroy = contains(["dev", "sandbox", "dev-chaos"], var.DEPLOYMENT_ENVIRONMENT)
 }
 
 # TODO: Create one bucket per environment? Or one bucket per version?


### PR DESCRIPTION
Cherry-picks the two dev-chaos sandbox commits from the stale workflow-infra chaos-engineering-dev branch onto current main (that branch predates the NT/NR fan-out and could not be merged wholesale without reverting it). Adds the DEPLOYMENT_ENVIRONMENT=dev-chaos disposable environment (environment.dev-chaos), makes its resources force-destroyable + tagged, for the pipeline chaos experiments (P1-P6, #808). Additive only -- touches environment/.gitignore/main.tf/buckets.tf, none of the index-generation fan-out files.