### PR TITLE
deploy: dev-chaos reuses the dev OIDC apply role (unblocks #808 sandbox)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
           # batch/states/lambda/ecr/s3. Replaces the shared idseq-support gha-seqtoid role. The
           # apply role is trusted only from refs/heads/main, which is the workflow_dispatch
           # default ref. CZID-40 (CICD-6) / CZID-81.
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment }}-gh-actions-apply
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment == 'dev-chaos' && 'dev' || inputs.environment }}-gh-actions-apply
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
           # aws-profile is load-bearing, not tidiness. `environment` derives the region with
@@ -221,7 +221,7 @@ jobs:
         with:
           # Same per-env least-privilege apply role and profile as the legacy job.
           # See the DeployTerraform job for why aws-profile is load-bearing.
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment }}-gh-actions-apply
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/czid-${{ inputs.environment == 'dev-chaos' && 'dev' || inputs.environment }}-gh-actions-apply
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
           aws-profile: idseq-${{ inputs.environment }}


### PR DESCRIPTION
Standing up the dev-chaos pipeline sandbox via deploy.yml env=dev-chaos assumed a non-existent czid-dev-chaos-gh-actions-apply role. dev-chaos is a logical sub-env of dev (same account, own state key + idseq-dev-chaos-* resources), and the dev apply role already trusts environment:dev* (glob includes dev-chaos). Map dev-chaos to the dev role while keeping DEPLOYMENT_ENVIRONMENT=dev-chaos for terraform. One-time prereq (not code): the dev-chaos GitHub Environment needs the AWS_ACCOUNT_ID var (dev account) + an optional reviewer.