### PR TITLE
ci(back-sync): self-merge the sync PR so integration stops drifting

### DIFF
--- a/.github/workflows/sync-main-to-integration.yml
+++ b/.github/workflows/sync-main-to-integration.yml
@@ -113,5 +113,19 @@ jobs:
           git push -u origin "$BRANCH"
           gh pr create --base integration --head "$BRANCH" \
             --title "sync: bring integration up to main" \
-            --body "Automated back-sync. \`integration\` was behind \`main\`; without this it keeps drifting and every feature PR into integration carries the backlog in its diff. Tracked in the platform-overhaul back-sync ticket (Forgejo 691)." \
+            --body "Automated back-sync. integration was behind main; without this it keeps drifting and every feature PR into integration carries the backlog in its diff. Tracked in the platform-overhaul back-sync ticket (Forgejo 691)." \
             || echo "a sync PR may already be open"
+
+          # Self-complete the back-sync so these PRs CONVERGE instead of piling up behind the
+          # integration 1-review rule. The synced content is by definition ALREADY on main --
+          # reviewed on the way in, or an approved direct-to-main hotfix -- so it does not need a
+          # fresh review on the way back down. Merge it with the app token (admin), exactly how
+          # gitops-advance-dev merges its own PRs. This is what makes "keeps integration from
+          # drifting" actually hold: without it the opened PR sat review-gated forever, which is
+          # the very drift this workflow exists to prevent. Falls back to auto-merge, then warns.
+          PRNUM="$(gh pr list --head "$BRANCH" --base integration --state open --json number --jq '.[0].number // empty' || true)"
+          if [ -n "$PRNUM" ]; then
+            gh pr merge "$PRNUM" --merge --admin --delete-branch \
+              || gh pr merge "$PRNUM" --merge --auto --delete-branch \
+              || echo "::warning::sync PR #$PRNUM could not be auto-merged; reconcile integration by hand."
+          fi


### PR DESCRIPTION
The main->integration back-sync opened a review-gated PR per push to main but never merged it, so they piled up (8-14 deep) behind integration's 1-review rule -- the very drift it exists to prevent. This self-merges the sync PR with the admin app token (as gitops-advance-dev already does), since the content is already on main. Falls back to auto-merge, then a warning.