### PR TITLE
index-generation: provision compress scratch IOPS/throughput and raise the compress SFN cap

### DIFF
--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -106,9 +106,29 @@ locals {
       # box, so max_vcpus must fit BOTH at once (2 x 48 = 96) -- at 48 they would serialize
       # and silently lose the compress parallelism the fan-out exists for. Each lane still
       # gets its own r6i.12xlarge node + its own 4 TB scratch (isolated, no shared-disk #798).
-      max_vcpus    = 96
-      scratch_gb   = 4096
-      provisioning = "EC2"
+      max_vcpus  = 96
+      scratch_gb = 4096
+      # EBS PERFORMANCE OVERRIDE (compress only). ncbi-compress is the one index-generation
+      # stage that is disk-throughput-bound, not CPU-bound: it streams the whole core_nt.fsa
+      # out to ~2.3M per-taxid files and reads them all back. On gp3 DEFAULTS (3,000 IOPS /
+      # 125 MiB/s -- what every stage got before this override) the full-scale run has a
+      # ~26 h I/O floor, which is over the 48 h SFN attempt cap's old 24 h value and wastes
+      # ~50 USD of idle 48-vCPU box per run waiting on the disk. The 8 GiB core_nt slice
+      # de-risk run confirmed the volume was pinned at 3000/125.
+      #
+      # 16,000 IOPS / 1,000 MiB/s drops that floor to ~3.3 h and makes the stage CPU-bound
+      # (~8-10 h). r7g.12xlarge has ~1,875 MiB/s of EBS bandwidth so 1,000 MiB/s is inside
+      # the instance limit with headroom. Cost of the provisioned extra is ~0.137 USD/hour,
+      # i.e. ~5 USD per run -- an order of magnitude less than the idle-compute it saves.
+      #
+      # Scoped deliberately: the launch template is created per-stage (for_each over this
+      # map), so only the compress stage's template carries the override. Every other stage
+      # leaves these null and keeps gp3 defaults -- the download stages are network-bound on
+      # the NCBI pull and the index stages are CPU/RAM-bound, so paying for provisioned IOPS
+      # there would be pure cost with no wall-clock return.
+      scratch_iops       = 16000
+      scratch_throughput = 1000
+      provisioning       = "EC2"
     }
     index_spot = {
       instance_types_x86      = ["r6i.4xlarge", "r6i.8xlarge", "r6i.12xlarge"]
@@ -129,12 +149,18 @@ locals {
   # Effective per-stage map consumed by the launch templates, compute environments, and
   # queues below. Selects the x86 or Graviton family per stage from var.use_graviton; every
   # other field is copied through unchanged. This is the single place the arch switch happens.
+  # scratch_iops / scratch_throughput are OPTIONAL per-stage gp3 performance overrides: a
+  # stage that does not declare them resolves to null here and the launch template omits the
+  # argument, leaving AWS's gp3 defaults (3,000 IOPS / 125 MiB/s). Only `compress` sets them
+  # today -- see the comment on that stage for why.
   index_generation_stages = {
     for name, cfg in local.index_generation_stages_base : name => {
-      instance_types = var.use_graviton ? cfg.instance_types_graviton : cfg.instance_types_x86
-      max_vcpus      = cfg.max_vcpus
-      scratch_gb     = cfg.scratch_gb
-      provisioning   = cfg.provisioning
+      instance_types     = var.use_graviton ? cfg.instance_types_graviton : cfg.instance_types_x86
+      max_vcpus          = cfg.max_vcpus
+      scratch_gb         = cfg.scratch_gb
+      scratch_iops       = try(cfg.scratch_iops, null)
+      scratch_throughput = try(cfg.scratch_throughput, null)
+      provisioning       = cfg.provisioning
     }
   }
 }
@@ -280,11 +306,15 @@ resource "aws_launch_template" "index_generation" {
   }
 
   # Single per-stage scratch volume (gp3), sized to that phase's working set only.
+  # iops/throughput are null for every stage except compress, and a null argument is omitted
+  # so those volumes keep the gp3 baseline (3,000 IOPS / 125 MiB/s).
   block_device_mappings {
     device_name = "/dev/sdf"
     ebs {
       volume_size           = each.value.scratch_gb
       volume_type           = "gp3"
+      iops                  = each.value.scratch_iops
+      throughput            = each.value.scratch_throughput
       encrypted             = true
       delete_on_termination = true
     }

--- a/terraform/sfn_templates/index-generation.yml
+++ b/terraform/sfn_templates/index-generation.yml
@@ -195,8 +195,15 @@ States:
               JobQueue: "${index_generation_compress_job_queue_arn}"
               JobName.$: $$.Execution.Name
               JobDefinition: *JobDefinition
+              # Anchor shared by CompressNR and CompressNT (the two Phase-2 lanes).
+              # Raised 24h -> 48h. At gp3 defaults the full-scale core_nt compress had a
+              # ~26 h I/O floor, i.e. it would have hit the old 24 h cap and been killed
+              # after a full day of paid compute. The provisioned-IOPS scratch volume
+              # (index-generation.tf, compress stage) brings the expected wall clock to
+              # ~8-10 h, so this is headroom, not the primary fix: it exists so a slow run
+              # finishes and can be measured rather than being truncated at the cap.
               Timeout: &CompressBatchTimeout
-                AttemptDurationSeconds: 86400 # 24 hours
+                AttemptDurationSeconds: 172800 # 48 hours
               ContainerOverrides:
                 Memory.$: $.CompressEC2Memory
                 Environment:


### PR DESCRIPTION
## Why

An 8 GiB slice of `core_nt.fsa` was pushed through the real CompressNT WDL/Batch path as a
de-risk (succeeded, 33 min, output validated). That run surfaced this: the compress node's
scratch volume was live at **4096 GiB gp3, 3,000 IOPS / 125 MiB/s** -- the gp3 baseline.

`aws_launch_template.index_generation` sets `volume_size` and `volume_type` but never `iops`
or `throughput`, so every index-generation stage has been running on gp3 defaults. Compress is
the one stage that is disk-throughput-bound rather than CPU-bound (it streams core_nt out to
~2.3M per-taxid files and reads them all back).

At 125 MiB/s the full-scale core_nt compress has a **~26 h I/O floor**, which is **over the 24 h
SFN attempt cap**. A full run as configured would have been killed by Step Functions after a
full day of paid 48-vCPU compute, having produced nothing.

## What

**1. Per-stage gp3 performance override, scoped to compress**

Adds optional `scratch_iops` / `scratch_throughput` to the stage map and wires them into the
launch template's `block_device_mappings`. Only `compress` sets them (16000 / 1000).

The launch template is created **per-stage** (`for_each = local.index_generation_stages`), so
this is genuinely compress-only rather than a blanket change: every other stage resolves these
to `null`, the argument is omitted, and those volumes keep the gp3 baseline. That is deliberate
-- the download stages are network-bound on the NCBI pull and the index stages are CPU/RAM-bound,
so provisioned IOPS there would be pure cost with no wall-clock return.

- 1,000 MiB/s is inside the r7g.12xlarge EBS bandwidth (~1,875 MiB/s), with headroom.
- Cost: ~0.137 USD/hour of provisioned extra, i.e. **~5 USD per run**, against **~50 USD/run** of
  idle 48-vCPU compute recovered.
- Expected effect: I/O floor **~26 h -> ~3.3 h**, making the stage CPU-bound at **~8-10 h**.

**2. Compress SFN attempt timeout 24 h -> 48 h**

Raises the `CompressBatchTimeout` anchor in `sfn_templates/index-generation.yml` from 86400 to
172800. The anchor is shared by both Phase-2 lanes, so this covers CompressNR and CompressNT.

This is belt-and-braces, not the fix. With the faster volume the stage should finish in ~8-10 h;
the headroom exists so that an unexpectedly slow run *finishes and can be measured* instead of
being truncated at the cap. Download (12 h) and Index (24 h) caps are unchanged.

Both changes are part of one concern -- making the full-scale compress stage able to complete --
and land in the same targeted apply, which is why they are in one PR.

## Validation

- `make check`: fmt clean, tflint clean, gitleaks clean, trivy clean. (`codegen/validate`
  is skipped locally -- needs the lambda build toolchain -- CI runs it.)
- SFN template re-parsed after the edit; both `CompressNR` and `CompressNT` now resolve to
  `AttemptDurationSeconds: 172800`, and no other state's timeout moved.

## Deploy

**Not applied.** Applies are reviewer-gated. After merge this needs a targeted apply on dev
covering the compress launch template + compute environment and the state machine.

Note the launch template has `update_default_version = true`, so the new version becomes the
CE's default and newly launched compress instances pick up the faster volume. Instances already
running keep their old volume.
