### PR TITLE
start_index_generation: stop auto-seeding compression, and only treat dated index dirs as prior runs

### DIFF
--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from uuid import uuid4
 
 import boto3
@@ -128,9 +129,25 @@ def start_index_generation(event, *args):
     sfn = boto3.client("stepfunctions")
     s3 = boto3.client("s3")
 
-    # Seed the taxonomy lineage build + the compress lanes incrementally from the most recent
-    # prior run, if any (Lever 4 -- unchanged inputs cache-hit; a seeded compress only builds
-    # the delta).
+    # Discover the most recent prior run's artifacts. Used for (a) the taxonomy lineage
+    # incremental build and (b) the Lever 4 refresh_scope reuse path, where an out-of-scope DB
+    # lane is fed the prior compressed fasta directly and skips compression entirely.
+    #
+    # These are NOT used to seed compression any more -- see the comment on compress_nt_input
+    # below.
+    #
+    # ELIGIBILITY: only keys under a DATE-named index directory
+    # (ncbi-indexes-<env>/YYYY-MM-DD.../) count as a prior run. The previous code scanned the
+    # whole ncbi-indexes-<env>/ prefix and took the lexicographically greatest match, so any
+    # ad-hoc sibling prefix could win purely on sort order -- and one did: a smoke-test
+    # directory ("smoketest-graviton/...") sorted above every real dated run, so the prepared
+    # full-run input was pointed at a 386-byte synthetic ACGT artifact. Sorting a smoke-test
+    # fixture ahead of a real index is the actual defect; restricting the scan to dated index
+    # directories fixes it for BOTH consumers (a scoped refresh would otherwise have reused
+    # that same 386-byte file as provided_nt and skipped compression, yielding an empty index).
+    prior_run_key = re.compile(
+        rf"^ncbi-indexes-{re.escape(deployment_environment)}/\d{{4}}-\d{{2}}-\d{{2}}[^/]*/"
+    )
     previous_lineages = None
     previous_nt_compressed = None
     previous_nr_compressed = None
@@ -141,6 +158,8 @@ def start_index_generation(event, *args):
     for page in pages:
         for obj in page.get("Contents", []):
             key = obj["Key"]
+            if not prior_run_key.match(key):
+                continue
             if key.endswith("versioned-taxid-lineages.csv.gz") and (
                 not previous_lineages or key > previous_lineages
             ):
@@ -200,13 +219,26 @@ def start_index_generation(event, *args):
     if provided_nr:
         download_nr_input["provided_nr"] = provided_nr
 
+    # NO AUTO-SEEDING. These lanes used to be handed previous_nt_compressed /
+    # previous_nr_compressed so ncbi-compress would run in seeded ("incremental") mode against
+    # the prior run. That is removed because seeded compression is BROKEN in a way that fails
+    # GREEN: it emits the DELTA ONLY -- input records contained in the seed are dropped, the
+    # seed's own records are never written to the output, and nothing downstream recombines
+    # them (the NT index lane builds from CompressNT.compressed). A seeded run therefore
+    # produces an index missing everything the seed represented, with no error and no warning.
+    #
+    # This is not hypothetical: the prepared full core_nt rerun input was auto-seeded from a
+    # 386-byte synthetic smoke-test artifact and would have shipped a silently incomplete
+    # index. The underlying ncbi-compress defects (delta-only output, the seed re-sketched
+    # once per taxid file, and seed suppression leaking across unrelated taxa) are tracked on
+    # Forgejo as the seeded-compression bug; feat/ncbi-compress-seed-fasta must not merge
+    # as-is. Re-enable seeding here only once that is fixed AND a seeded rebuild has been
+    # AUPR-benchmarked as equivalent to a full rebuild.
+    #
+    # The Lever 4 refresh_scope reuse path below is unaffected: it reuses the prior compressed
+    # fasta WHOLE (as the download output) and skips compression, so no delta semantics apply.
     compress_nt_input = {"docker_image_id": docker_image_id}
-    if previous_nt_compressed:
-        compress_nt_input["previous_nt_compressed"] = s3_uri(previous_nt_compressed)
-
     compress_nr_input = {"docker_image_id": docker_image_id}
-    if previous_nr_compressed:
-        compress_nr_input["previous_nr_compressed"] = s3_uri(previous_nr_compressed)
 
     # Lever 4 (802) refresh_scope: an out-of-scope DB lane reuses the prior run's compressed
     # fasta and skips (re)compression, so a scoped refresh pays neither the download nor the

--- a/terraform/start_index_generation_lambda_src/test_main_lever4.py
+++ b/terraform/start_index_generation_lambda_src/test_main_lever4.py
@@ -11,10 +11,17 @@ import types
 captured = {"sfn_input": None, "put_objects": []}
 
 _PRIOR = "ncbi-indexes-dev/2026-07-09/index-generation-2"
+# A smoke-test directory that sorts ABOVE every real dated index run. This is the exact shape
+# that poisoned the prepared full-run input: 386-byte synthetic artifacts under a non-dated
+# sibling prefix won on lexicographic order. Nothing under it may ever be selected.
+_SMOKE = "ncbi-indexes-dev/smoketest-graviton/be3e4378c/download"
 _PRIOR_KEYS = [
     f"{_PRIOR}/nt_compressed.fa",
     f"{_PRIOR}/nr_compressed.fa",
     f"{_PRIOR}/versioned-taxid-lineages.csv.gz",
+    f"{_SMOKE}/nt_compressed.fa",
+    f"{_SMOKE}/nr_compressed.fa",
+    f"{_SMOKE}/versioned-taxid-lineages.csv.gz",
 ]
 
 
@@ -73,14 +80,19 @@ def run(scope=None, extra=None):
     return captured["sfn_input"]["Input"]
 
 
-# ---- full (default): priors seed incremental compression, NO scope-driven reuse skip ----
+# ---- full (default): a full rebuild, NEVER seeded, NO scope-driven reuse skip ----
+# Seeded compression emits the delta only and nothing recombines seed + delta, so an
+# auto-seeded "full" run silently produces an incomplete index. The lambda must never inject
+# previous_*_compressed into a compress lane, even though a prior run exists in the listing.
 inp = run("full")
 assert "provided_nt" not in inp["DownloadNT"], "full: NT must download, not reuse"
 assert "provided_nr" not in inp["DownloadNR"], "full: NR must download, not reuse"
 assert "skip_nuc_compression" not in inp["CompressNT"]
 assert "skip_protein_compression" not in inp["CompressNR"]
-assert inp["CompressNT"]["previous_nt_compressed"] == _PRIOR_NT, "full: still seeds incremental"
-assert inp["CompressNR"]["previous_nr_compressed"] == _PRIOR_NR
+assert "previous_nt_compressed" not in inp["CompressNT"], "full: must NOT seed compression"
+assert "previous_nr_compressed" not in inp["CompressNR"], "full: must NOT seed compression"
+assert inp["CompressNT"] == {"docker_image_id": inp["CompressNT"]["docker_image_id"]}
+assert inp["CompressNR"] == {"docker_image_id": inp["CompressNR"]["docker_image_id"]}
 
 # ---- nt_only: NT builds fully; NR reuses prior + skips compression ----
 inp = run("nt_only")
@@ -118,6 +130,20 @@ assert inp["DownloadTaxonomy"]["provided_taxdump"] == "s3://other-bucket/snap/20
 # ---- explicit skip override wins over scope default ----
 inp = run("nr_only", {"skip_nuc_compression": False})
 assert inp["CompressNT"]["skip_nuc_compression"] is False, "explicit override must win"
+
+# ---- prior-run discovery ignores non-dated (smoke-test) prefixes ----
+# _SMOKE sorts above _PRIOR, so if the scan were still unrestricted these would resolve to the
+# smoke-test artifacts and a scoped refresh would reuse a 386-byte synthetic file as the whole
+# database. Every consumer of the discovered priors must land on the real dated run.
+inp = run("lineage_only")
+assert _SMOKE not in inp["DownloadNT"]["provided_nt"], "must not reuse a smoke-test artifact"
+assert _SMOKE not in inp["DownloadNR"]["provided_nr"], "must not reuse a smoke-test artifact"
+assert inp["DownloadNT"]["provided_nt"] == _PRIOR_NT
+assert inp["DownloadNR"]["provided_nr"] == _PRIOR_NR
+assert _SMOKE not in inp["IndexTaxonomy"]["previous_lineages"]
+assert inp["IndexTaxonomy"]["previous_lineages"].endswith(
+    f"{_PRIOR}/versioned-taxid-lineages.csv.gz"
+)
 
 # ---- invalid scope rejected ----
 try:


### PR DESCRIPTION
## Why

While de-risking the full core_nt index-generation run, the prepared full-run input
(`s3://seqtoid-public-references/ncbi-indexes-dev/2026-07-23/PREPARED-full-rerun-input.json`)
turned out to point `CompressNT.previous_nt_compressed` and `CompressNR.previous_nr_compressed`
at the **2026-07-21 smoke-test artifacts** -- 386 bytes and 180 bytes of synthetic ACGT
150-mers.

That input was not hand-written. This lambda generated it. Two independent defects combined.

### 1. It auto-seeded compression, and seeded compression fails GREEN

Whenever any prior compressed fasta existed, the lambda injected `previous_*_compressed`,
putting `ncbi-compress` into seeded ("incremental") mode.

Seeded compression emits the **delta only**:
- input records contained in the seed are dropped;
- the seed's own records are never written to the output (the implementation comment says so
  outright);
- nothing downstream recombines them -- the NT index lane builds from `CompressNT.compressed`.

So a seeded run produces an index missing everything the seed represented, and it **succeeds**.
No error, no warning, no count check. With a 386-byte synthetic seed the loss happens to be
small; with a real seed it would be most of the database.

### 2. Prior-run discovery had no notion of what a prior run *is*

It scanned the entire `ncbi-indexes-<env>/` prefix and took the lexicographically greatest
matching key. Any ad-hoc sibling prefix could therefore win purely on sort order -- and one did:
`smoketest-graviton/` sorts above every dated index run.

This is the more dangerous of the two, because it is **not** confined to the seeding path. The
Lever 4 `refresh_scope` reuse path feeds the discovered artifact straight to the download lane
as `provided_nt` / `provided_nr` and sets `skip_*_compression`. So a scoped refresh
(`nr_only`, `nt_only`, `lineage_only`) would have reused that same 386-byte file as the **entire
database** and skipped compression -- an empty index, again fully green. `previous_lineages` had
identical exposure.

## What

- **Remove auto-seeding.** Both compress lanes now carry `docker_image_id` only. The underlying
  `ncbi-compress` defects (delta-only output; the seed re-sketched once per taxid file, i.e.
  ~2.3M times for core_nt; and seed suppression leaking across unrelated taxa) are tracked in a
  Forgejo bug. Seeding should be re-enabled here only once those are fixed **and** a seeded
  rebuild has been AUPR-benchmarked as equivalent to a full rebuild.
- **Restrict prior-run discovery to date-named index directories**
  (`ncbi-indexes-<env>/YYYY-MM-DD.../`), so a smoke-test or scratch prefix can never be selected
  as a prior run by any consumer.

The `refresh_scope` reuse path itself is untouched and still correct: it reuses the prior
compressed fasta **whole** and skips compression, so no delta semantics apply.

## Tests

`test_main_lever4.py` now seeds the fake S3 listing with a `smoketest-graviton/` prefix that
sorts **above** the real dated run, and asserts:

- a `full` run injects **no** `previous_*_compressed` at all (both compress inputs are exactly
  `{docker_image_id}`);
- every consumer of the discovered priors -- `provided_nt`, `provided_nr`, `previous_lineages`
  -- resolves to the dated run and never to the smoke-test prefix.

Both `test_main.py` and `test_main_lever4.py` pass. `make check` clean (fmt, tflint, gitleaks,
trivy; codegen/validate is CI-only).

## Related

A corrected canonical input with the `previous_*` keys removed is staged at
`s3://seqtoid-public-references/ncbi-indexes-dev/2026-07-23/CANONICAL-full-rerun-input.NO-SEED.json`.
It was verified to differ from the original in **exactly** those two leaves and nothing else
(33 of 35 leaf paths byte-identical, none added, none changed), and every S3 URI it references
was confirmed to exist.

No apply here -- this is lambda source; it ships on the next deploy of the
`start_index_generation` lambda.
