### PR TITLE
fix(dev outage): repoint swipe module/image at v1.4.9-ucsf.5 (restores all user workflows + deploys handle_failure fix)

### DIFF
--- a/terraform/index-generation-arm64-jobdef.tf
+++ b/terraform/index-generation-arm64-jobdef.tf
@@ -1,8 +1,11 @@
 # Dedicated arm64 (Graviton) Batch job definition for the multi-stage index-generation stages
 # (Lever 2, CZID-776).
 #
-# The shared swipe main job-def (idseq-swipe-dev-main) runs the amd64 SWIPE runner image
-# (ghcr.io/chanzuckerberg/swipe:v1.4.9). AWS Batch launches THAT orchestrator image (not our
+# The shared swipe main job-def (idseq-swipe-dev-main) runs the amd64 SWIPE runner image.
+# (That image reference is rendered by the swipe module from its own `version` file -- it was
+# ghcr.io/chanzuckerberg/swipe:v1.4.9 when this file was written, then an ECR -ucsf tag. It is
+# NOT hardcoded here or anywhere else in this repo; see the note in swipe.tf.) AWS Batch
+# launches THAT orchestrator image (not our
 # per-task index-generation image), and it is amd64-only, so on the arm64/Graviton
 # index-generation compute environments it dies with `exec /usr/local/bin/init.sh: exec format
 # error`. This job-def is a clone of the deployed swipe_main container properties with the

--- a/terraform/swipe.tf
+++ b/terraform/swipe.tf
@@ -5,7 +5,25 @@ module "swipe" {
   # (merge_parallel_outputs) that lets the Parallel per-DB Download state merge its
   # outputs -- required for the NT/NR fan-out SFN. The fork adds one new required input
   # (restricted_files), supplied below.
-  source = "github.com/IT-Academic-Research-Services/swipe?ref=v1.4.9-ucsf.4"
+  #
+  # This ref is load-bearing for the CONTAINER IMAGE as well as the code. The module
+  # renders the Batch image reference from its own `version` file:
+  #
+  #   batch_job_docker_image = "<account>.dkr.ecr.us-west-2.amazonaws.com/swipe:${chomp(version)}"
+  #
+  # At ref ucsf.4 that file still said `v1.4.9-ucsf.3` -- a tag that has NEVER existed in
+  # the dev account. The -ucsf.x images were only ever pushed to the old shared registry
+  # account 941377154785 and were not migrated when dev was isolated, so every SWIPE
+  # container died at CannotPullImageManifestError and every user workflow failed. Moving
+  # to ucsf.5 is what repoints idseq-swipe-<env>-main at a real image; there is no
+  # separate image field to edit in this repo.
+  #
+  # ucsf.5 also carries (a) a genuine multi-arch amd64+arm64 runner image, so one image
+  # serves both the x86_64 user-facing CEs and the arm64 index-generation CEs, and (b) the
+  # sfn-io-helper handle_failure fix that reports the real error instead of
+  # KeyError: 'Error'. Both ride this ref because the module is pinned whole -- the
+  # lambdas are not separately deployable.
+  source = "github.com/IT-Academic-Research-Services/swipe?ref=v1.4.9-ucsf.5"
   tags = {
     Name = "swipe"
   }


### PR DESCRIPTION
## The outage

Every user workflow in dev (short-read-mngs, default, ...) has been failing since roughly
2026-07-22 18:26. The Batch job definition `idseq-swipe-dev-main` (revision 8) requests

    491013321714.dkr.ecr.us-west-2.amazonaws.com/swipe:v1.4.9-ucsf.3

The SWIPE orchestrator container therefore never starts:
`CannotPullImageManifestError: manifest unknown`. Because that container is what runs the WDL,
nothing downstream runs -- this is total, not partial.

## Root cause: an image reference that outlived the registry it pointed at

The tag `v1.4.9-ucsf.3` has **never existed** in the dev account. CloudTrail on the dev `swipe`
ECR repository shows exactly one event -- `CreateRepository`, 2026-07-21. Nothing deleted it.

The `-ucsf.x` images were only ever pushed to the **old shared registry account 941377154785**
(the stale idseq-support account), and were never migrated when dev was isolated into its own
account. Cross-account pulls now fail with AccessDenied.

Revisions 1-7 of this job definition pointed at `ghcr.io/chanzuckerberg/swipe:v1.4.9` -- public
and always pullable. Revision 8 moved it to a private ECR tag in an account that did not have
the image.

**Why grep did not find it:** the image reference is not written anywhere in this repo. The
swipe module renders it from its own `version` file:

    batch_job_docker_image = "<account>.dkr.ecr.us-west-2.amazonaws.com/swipe:${chomp(version)}"

So the only way to repoint the job definition is to move the module ref. Three references
disagreed: module pinned at `ucsf.4`, image tag rendered as `ucsf.3`, and the only image
actually present in dev ECR was `v1.4.9-seqtoid.1-arm64`. This change collapses them into one.

## Second defect: architecture mismatch

Every image in the dev `swipe` repo was arm64-only, but the user-facing compute environments
are x86_64. Repointing at the existing tag would have swapped `manifest unknown` for
`exec format error`.

| compute environment | instances | AMI | arch |
| --- | --- | --- | --- |
| `idseq-swipe-dev-spot` / `-on_demand` (user-facing) | `r5d` | `amzn2-ami-ecs-hvm-2.0.20260721-x86_64-ebs` | **x86_64** |
| `idseq-dev-index-generation-*` | `r7g` / `m7g` | `amzn2-ami-ecs-hvm-2.0.20260721-arm64-ebs` | **arm64** |

Both are served by publishing a genuine multi-arch image.

## The new image

Published to dev ECR as `swipe:v1.4.9-ucsf.5`, built from swipe PR 10.

    index (manifest list)  sha256:92f4b26019ac08d9d1cbbc4fbe82a19e5bdfa6ebc5017ad605f35a2abeb96813
      linux/amd64          sha256:8eedc29a0926092fa02f5bbc078bb9ecc2531197a10858c00f7538e989c9467e
      linux/arm64          sha256:579d8dc976213b9457acbbeef2ac0b77b01135e9a32f6058084c754992c03116

Verified, not assumed:

- `aws ecr batch-get-image` with manifest-list media types confirms the index contains both
  `linux/amd64` and `linux/arm64` entries;
- each child manifest's **config blob** was downloaded and read -- `architecture` is `amd64`
  and `arm64` respectively, so the manifest list is not lying;
- the vendored arch-specific binaries (`s3parcp`, `docker-credential-ecr-login`) were
  ELF-header-checked inside each image and are natively x86-64 and aarch64 respectively.

That last check is not paranoia. The first build of this image passed the manifest and config
blob checks and was still wrong: `ARG TARGETARCH=amd64` shadows the value BuildKit injects, so
the arm64 image contained amd64 binaries while reporting `arm64` everywhere including
`uname -m`. Fixed by redeclaring the ARG with no default; details in swipe PR 10.

## What rides along: the handle_failure fix

This module is pinned **whole** by git ref, so the sfn-io-helper lambdas are not separately
deployable -- there is no path that updates `handle_failure` without moving this ref.

`handle_failure` raised `KeyError: 'Error'` when a Catch scoped the error per state, so
pipeline failures reported the KeyError instead of their real cause. That is why this outage
went roughly 36 hours undiagnosed. The fix merged in swipe PR 9 (2026-07-24 00:17 UTC) but the
deployed lambda was last modified 2026-07-23 13:17 UTC, so it is **not currently deployed**.

Shipping it in the same apply is deliberate: if this repoint turns out to be incomplete, we
want the next failure to name its real cause instead of masking it again.

**This single apply restores user workflows AND deploys the handle_failure fix.**

## Changes here

- `terraform/swipe.tf` -- module ref `v1.4.9-ucsf.4` -> `v1.4.9-ucsf.5`, plus a comment
  explaining that this ref is load-bearing for the container image, so the next person does not
  go looking for an image field that does not exist.
- `terraform/index-generation-arm64-jobdef.tf` -- comment only, no terraform diff. It claimed
  the shared main job-def runs `ghcr.io/chanzuckerberg/swipe:v1.4.9`, which is stale and was
  actively misleading during diagnosis.

Nothing else in this repo references the dead `ucsf.3` tag or registry 941377154785 (`MAINTENANCE.md`
item A5 mentions the account, but that entry is itself stale -- `deploy.yml` now uses
`vars.AWS_ACCOUNT_ID`).

## Prerequisites

1. Merge swipe PR 10.
2. Cut tag `v1.4.9-ucsf.5` at that merge commit.

The image is **already in dev ECR**, so once the tag exists this applies cleanly. Terraform will
fail fast on an unresolvable module ref if step 2 is skipped.

## Apply (reviewer-gated, dev only)

Not applied. Run via `targeted-apply`, which renders the scoped plan first and pauses for
approval in the `dev-targeted` GitHub Environment:

    gh workflow run targeted-apply.yml \
      --repo IT-Academic-Research-Services/cypherid-workflow-infra \
      --ref fix/swipe-image-outage-ucsf5 \
      -f environment=dev \
      -f targets="module.idseq.module.swipe.module.sfn.module.batch_job.aws_batch_job_definition.swipe_main module.idseq.module.swipe.module.sfn.module.sfn_io_helper.aws_lambda_function.lambda"

Note the `module.idseq.` prefix -- the whole configuration is wrapped in a root `module.idseq`,
so the shorter `module.swipe....` addresses do NOT exist and would silently target nothing.
Both addresses were confirmed against the live state in
`s3://tfstate-491013321714-test/idseqdev`, which currently records
`revision = 8` and `image = ...swipe:v1.4.9-ucsf.3` for the job definition.

Both targets are required: the job definition is the image repoint, and the lambda resource
(a `for_each` over the 9 sfn-io-helper lambdas -- `handle_failure`, `handle_success`,
`merge_parallel_outputs`, `preprocess_input`, `process_batch_event`, `process_sfn_event`,
`process_stage_output`, `report_metrics`, `report_spot_interruption`) is the `handle_failure`
fix. Both move with this ref.

The Step Functions state machines do **not** need to be in scope -- they reference the job
definition by NAME (`module.batch_job.batch_job_definition_name` returns
`aws_batch_job_definition.swipe_main.name`, not an ARN with a revision), so a new revision is
picked up automatically.

## Blast radius / safety

- **dev only.**
- Registers a new revision of `idseq-swipe-dev-main`; does not mutate queues or compute
  environments.
- Does **not** touch `idseq-swipe-dev-index-generation-arm64` or its dedicated queues. The
  core_nt index-generation execution `index-generation-core-nt-v252-20260724-032146` is
  currently RUNNING and is deliberately left alone. Retiring that arm64 job-def in favour of
  the now-multi-arch image is a follow-up, after that run completes.
- No image tag was overwritten: `v1.4.9-seqtoid.1-arm64` is untouched, and `ucsf.5` is new.
