### PR TITLE
[ON-HOLD] perf(index-gen): size compress CE for r8g Graviton4 so NR scales (869)

### DIFF
--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -102,22 +102,19 @@ locals {
       instance_types_x86      = ["r6i.32xlarge", "r6i.12xlarge"] # 128 vCPU / 1024 GB ; 48 / 384
       instance_types_graviton = ["r8g.48xlarge", "r8g.12xlarge"] # 192 vCPU / 1536 GB (Graviton4) ; 48 / 384
       # Fan-out (800): CompressNR and CompressNT are the two Phase-2 lanes, both submitted to this
-      # one compute environment. Batch selects the instance by the job's MEMORY request (the vcpu
-      # request is 1; the container then uses every core of the instance it lands on), and that
-      # memory comes from a SINGLE knob -- COMPRESS_MEMORY in the launcher lambda, emitted as
-      # CompressEC2Memory for BOTH lanes (869):
-      #   - COMPRESS_MEMORY = 1450000 (1450 GB) fits only r8g.48xlarge (1536 GB / 192 vCPU,
-      #     Graviton4). CompressNR runs there across all 192 cores: ncbi-compress now parallelizes
-      #     ACROSS taxids (per-taxid dedup is independent), so it scales with cores instead of the
-      #     old serial one-taxid-at-a-time loop that pinned 48 cores at 99% for ~34 h on core_nt.
-      #   - Because the knob is shared, CompressNT ALSO requests 1450 GB and lands on r8g.48xlarge
-      #     too. It is I/O-bound (the EBS override below is for it) and does not need the cores, so
-      #     this is wasteful, and with max_vcpus 256 the two lanes cannot both hold an r8g.48xlarge
-      #     (2 x 192 > 256) -- they SERIALIZE rather than overlap. Splitting the knob into
-      #     COMPRESS_NR_MEMORY / COMPRESS_NT_MEMORY (NT back to 384 GB -> r8g.12xlarge, lanes
-      #     overlap again) is a tracked follow-up; correctness holds without it.
-      # max_vcpus 256 holds one r8g.48xlarge (192) with headroom; raise it if the knob is split so
-      # NR(192) + NT(48) can run concurrently.
+      # one compute environment and running CONCURRENTLY. Batch selects each lane's instance by its
+      # MEMORY request (the vcpu request is 1; the container then uses every core of the instance it
+      # lands on), and each lane has its OWN memory knob in the launcher lambda (869):
+      #   - CompressNR (COMPRESS_NR_MEMORY 1450 GB) -> r8g.48xlarge (1536 GB / 192 vCPU, Graviton4).
+      #     ncbi-compress now parallelizes ACROSS taxids (per-taxid dedup is independent), so it
+      #     scales with cores instead of the old serial one-taxid-at-a-time loop that pinned 48
+      #     cores at 99% for ~34 h on core_nt. The large RAM is what lets many taxid units run at
+      #     once.
+      #   - CompressNT (COMPRESS_NT_MEMORY 384 GB) -> r8g.12xlarge (48 vCPU). NT is I/O-bound (the
+      #     EBS override below is for it); more cores do nothing, so it stays small and cheap and
+      #     runs alongside NR rather than contending for the big box.
+      # max_vcpus must fit BOTH instances concurrently: r8g.48xlarge (192) + r8g.12xlarge (48) = 240
+      # instance vCPUs, so 256 leaves headroom for both lanes at once.
       max_vcpus  = 256
       scratch_gb = 4096
       # EBS PERFORMANCE OVERRIDE (compress only). ncbi-compress is the one index-generation
@@ -545,17 +542,18 @@ resource "aws_lambda_function" "start_index_generation" {
       # Replaces the single MEMORY/VCPU override of the old monolith. VCPU is now set by
       # each stage's compute-environment instance family, not a container override.
       DOWNLOAD_MEMORY = "14000" # c6i.2xlarge (16 GB), IO-bound download
-      # Compress container memory (MB) -> emitted as CompressEC2Memory. Batch selects the compress
-      # instance by MEMORY (the job's vcpu request is 1; the container then uses all cores of the
-      # instance its memory footprint lands on), so this value is what steers the lane onto a given
-      # box. 1450000 (1450 GB) only fits r8g.48xlarge (1536 GB / 192 vCPU, 869 CE) -> the parallel-
-      # over-taxids NR compress runs across all 192 cores. r7g/r8g.12xlarge (384 GB) can no longer
-      # hold it, which is intended: the whole point of v2.5.3 is to stop pinning NR compress to 48
-      # cores. NOTE: this single knob feeds BOTH CompressNR and CompressNT, so CompressNT also
-      # requests 1450 GB and lands on r8g.48xlarge; with max_vcpus 256 the two Phase-2 lanes
-      # therefore serialize rather than run concurrently. Splitting into COMPRESS_NR_MEMORY /
-      # COMPRESS_NT_MEMORY (so NT keeps 384 GB and the lanes overlap) is a follow-up.
-      COMPRESS_MEMORY     = "1450000" # r8g.48xlarge (1536 GB / 192 vCPU), parallel ncbi-compress (869)
+      # Compress container memory (MB), one knob PER Phase-2 lane (869). Batch selects the compress
+      # instance by MEMORY (the job's vcpu request is 1; the container then uses every core of the
+      # instance its memory footprint lands on), so memory is what steers each lane onto a box. The
+      # two lanes size independently so they run CONCURRENTLY on the shared compress CE:
+      #   COMPRESS_NR_MEMORY 1450000 (1450 GB) fits only r8g.48xlarge (1536 GB / 192 vCPU) -> the
+      #     parallel-over-taxids NR compress runs across all 192 cores (was pinned to 48).
+      #   COMPRESS_NT_MEMORY 380000 (380 GB) fits r8g.12xlarge (384 GB / 48 vCPU). NT is I/O-bound,
+      #     so more cores do nothing; keeping it small lets it run alongside NR instead of fighting
+      #     for the big box. A single shared knob would force NT onto r8g.48xlarge too and, under
+      #     max_vcpus 256, serialize the lanes.
+      COMPRESS_NR_MEMORY  = "1450000" # r8g.48xlarge (1536 GB / 192 vCPU), parallel ncbi-compress
+      COMPRESS_NT_MEMORY  = "380000"  # r8g.12xlarge (384 GB / 48 vCPU), I/O-bound nt compress
       INDEX_SPOT_MEMORY   = "128000"  # index build on spot
       INDEX_EC2_MEMORY    = "250000"  # index build on the on-demand fallback
       BUCKET              = data.aws_s3_bucket.public-references.bucket

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -514,29 +514,29 @@ resource "aws_lambda_function" "start_index_generation" {
       # This one variable is the SSOT for BOTH the ECR image tag (index-generation:<version>) and the
       # S3 WDL prefix (index-generation-<version>/), so both must exist before it is bumped. Both do.
       #
-      # v2.5.3 -- parallel-over-taxids NR compress on Graviton (869). First version where the image
-      # AND the compress WDL come from the SAME lineage (main): the v2.5.2 image fixes previously
-      # lived on index-gen-lever2-fanout while the Lever 3 (801) WDLs lived on main, so v2.5.2 had to
-      # ship the image only and keep the v2.5.0 WDLs. Landing the parallel compress on main (seqtoid-
-      # workflows #41) plus the multi-arch CI build (#42) reconciles the compress path, so v2.5.3 can
-      # move the image and the WDL together.
-      #   ECR  index-generation:v2.5.3 -> sha256:2fddfeb9ebe3e3b573968d2f0bc0e6f2d149c184148e0aba8ce18b6cdcab7a1d
+      # v2.5.4 -- fully reconciled main lineage: parallel-over-taxids NR compress on Graviton (869),
+      # Lever 3 (801) download/index, AND the superkingdom-restore fix, all built from one main image.
+      # v2.5.3 moved the compress path onto main but its image was missing the superkingdom-restore
+      # fix (that fix had lived only on the lever2-fanout image line), so IndexTaxonomy's
+      # GenerateIndexLineages failed the core_nt run with KeyError ['superkingdom'] after NCBI's 2024
+      # rank overhaul dropped the literal superkingdom rank. Cherry-picking that fix (and its pandas
+      # test dep) onto main closes the last divergence, so v2.5.4 is the first version where every fix
+      # ships together.
+      #   ECR  index-generation:v2.5.4 -> sha256:7974969b5247f68b8136cedd1d2d3db3af71c8a57588804513444ac22ad5d7dc
       #        multi-arch (linux/amd64 + linux/arm64); the arm64 entry is what the r8g Graviton
-      #        compress nodes execute. Same digest as CI build 2bf9977 (== main a4ea320 tree) --
-      #        retagged, not rebuilt. First image published by CI as a single OCI index (v2.5.2 used
-      #        hand-built per-arch tags).
-      #   S3   index-generation-v2.5.3/ -> main's 9 fan-out sub-WDLs. The ONLY change vs v2.5.2 is
-      #        compress-nr.wdl (parallel-over-taxids compress; CompressNR sized to 192 vCPU / 1450G
-      #        with COMPRESS_TAXID_CONCURRENCY=96). The other 8 WDLs are byte-identical to v2.5.2, so
-      #        the Lever 3 download/index stages are unchanged.
+      #        compress nodes execute. Retag of the CI build of main commit 46de596 -- built, tested,
+      #        and published as a single OCI index by wdl-ci.
+      #   S3   index-generation-v2.5.4/ -> main's 9 fan-out sub-WDLs, byte-identical to v2.5.3 (the
+      #        superkingdom fix is in the IMAGE, not the WDLs).
       #
-      # COUPLING: v2.5.3's CompressNR requests 192 vCPU, which only places on the r8g compress
-      # compute environment sized in this same change. Apply the CE and this pin together; a pin bump
-      # without the r8g CE would leave CompressNR unschedulable.
+      # COUPLING: v2.5.4's CompressNR requests 192 vCPU, which only places on the r8g compress
+      # compute environment sized in this same change, and CompressNR/CompressNT split their memory
+      # via COMPRESS_NR_MEMORY / COMPRESS_NT_MEMORY below. Apply the CE, the SFN, and this pin
+      # together; the pin alone would leave CompressNR unschedulable.
       #
       # v2.5.1 is skipped on purpose: v2.5.1-superkingdom is a hand-built overlay image, and an
       # adjacent v2.5.1 release tag would be easy to confuse with it.
-      INDEX_GENERATION_WORKFLOW_VERSION = "v2.5.3"
+      INDEX_GENERATION_WORKFLOW_VERSION = "v2.5.4"
       AWS_ACCOUNT_ID                    = var.AWS_ACCOUNT_ID
       # Per-stage container memory (MB) for the multi-stage pipeline (Lever 1, Track A).
       # Replaces the single MEMORY/VCPU override of the old monolith. VCPU is now set by

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -99,14 +99,19 @@ locals {
       provisioning = "EC2"
     }
     compress = {
-      instance_types_x86      = ["r6i.12xlarge"] # 48 vCPU / 384 GB
-      instance_types_graviton = ["r7g.12xlarge"] # 48 vCPU / 384 GB (Graviton3)
-      # Fan-out (800): CompressNR and CompressNT run CONCURRENTLY (Phase-2 lanes), both on
-      # this one compress compute environment. Each ncbi-compress job needs the whole 48-vCPU
-      # box, so max_vcpus must fit BOTH at once (2 x 48 = 96) -- at 48 they would serialize
-      # and silently lose the compress parallelism the fan-out exists for. Each lane still
-      # gets its own r6i.12xlarge node + its own 4 TB scratch (isolated, no shared-disk #798).
-      max_vcpus  = 96
+      instance_types_x86      = ["r6i.32xlarge", "r6i.12xlarge"] # 128 vCPU / 1024 GB ; 48 / 384
+      instance_types_graviton = ["r8g.48xlarge", "r8g.12xlarge"] # 192 vCPU / 1536 GB (Graviton4) ; 48 / 384
+      # Fan-out (800): CompressNR and CompressNT run CONCURRENTLY (Phase-2 lanes) on this one
+      # compute environment. Batch places each lane on the SMALLEST listed instance that fits its
+      # runtime request, so the two lanes size INDEPENDENTLY (869):
+      #   - CompressNR requests 192 vCPU / 1450 GB -> r8g.48xlarge (Graviton4). ncbi-compress now
+      #     parallelizes ACROSS taxids (per-taxid dedup is independent), so it scales with cores
+      #     instead of the old serial one-taxid-at-a-time loop that pinned 48 cores at 99% for
+      #     ~34 h on core_nt. The large RAM is what lets many taxid units run concurrently.
+      #   - CompressNT requests 48 vCPU / 384 GB   -> r8g.12xlarge. NT is I/O-bound (the EBS
+      #     override below is for it); more cores do nothing, so it stays small and cheap.
+      # max_vcpus must fit BOTH concurrently: NR(192) + NT(48) = 240, rounded to 256 for headroom.
+      max_vcpus  = 256
       scratch_gb = 4096
       # EBS PERFORMANCE OVERRIDE (compress only). ncbi-compress is the one index-generation
       # stage that is disk-throughput-bound, not CPU-bound: it streams the whole core_nt.fsa

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -507,24 +507,32 @@ resource "aws_lambda_function" "start_index_generation" {
       # Fan-out index-generation version (semver SSOT, platform-overhaul #843). Must match the
       # published WDL prefix s3://<workflows>/index-generation-<VER>/ and the ECR tag
       # index-generation:<VER>. Bump all three together when releasing a new index-gen version.
-      # v2.5.2 -- the first index-generation release built from source by CI rather than by hand.
       # This one variable is the SSOT for BOTH the ECR image tag (index-generation:<version>) and the
-      # S3 WDL prefix (index-generation-<version>/), so both must exist before it is bumped. Both do:
-      #   ECR  index-generation:v2.5.2 -> sha256:2c98beb6f1eb36ad3f3458f99236827db8fa198a713bd844ddce4fae1ff29d88
-      #        multi-arch (linux/amd64 + linux/arm64); the arm64 entry is what the Graviton compress
-      #        nodes actually execute. Same digest as the CI build c5ffdf7 -- retagged, not rebuilt.
-      #   S3   index-generation-v2.5.2/ -> a BYTE-IDENTICAL copy of the v2.5.0 WDLs (9/9 etags match).
+      # S3 WDL prefix (index-generation-<version>/), so both must exist before it is bumped. Both do.
       #
-      # The WDLs are deliberately unchanged. The deployed v2.5.0 set carries the Lever 3 (801)
-      # parallel blastdbcmd extract, which lives on main; every fix in this image (superkingdom
-      # restore, the ncbi-compress split-chunk-size fix, the multi-arch build) lives on
-      # index-gen-lever2-fanout, which does NOT have Lever 3. Publishing WDLs from that branch would
-      # have silently regressed the download stage. So v2.5.2 changes the IMAGE ONLY. Reconciling the
-      # two lineages is tracked separately.
+      # v2.5.3 -- parallel-over-taxids NR compress on Graviton (869). First version where the image
+      # AND the compress WDL come from the SAME lineage (main): the v2.5.2 image fixes previously
+      # lived on index-gen-lever2-fanout while the Lever 3 (801) WDLs lived on main, so v2.5.2 had to
+      # ship the image only and keep the v2.5.0 WDLs. Landing the parallel compress on main (seqtoid-
+      # workflows #41) plus the multi-arch CI build (#42) reconciles the compress path, so v2.5.3 can
+      # move the image and the WDL together.
+      #   ECR  index-generation:v2.5.3 -> sha256:2fddfeb9ebe3e3b573968d2f0bc0e6f2d149c184148e0aba8ce18b6cdcab7a1d
+      #        multi-arch (linux/amd64 + linux/arm64); the arm64 entry is what the r8g Graviton
+      #        compress nodes execute. Same digest as CI build 2bf9977 (== main a4ea320 tree) --
+      #        retagged, not rebuilt. First image published by CI as a single OCI index (v2.5.2 used
+      #        hand-built per-arch tags).
+      #   S3   index-generation-v2.5.3/ -> main's 9 fan-out sub-WDLs. The ONLY change vs v2.5.2 is
+      #        compress-nr.wdl (parallel-over-taxids compress; CompressNR sized to 192 vCPU / 1450G
+      #        with COMPRESS_TAXID_CONCURRENCY=96). The other 8 WDLs are byte-identical to v2.5.2, so
+      #        the Lever 3 download/index stages are unchanged.
+      #
+      # COUPLING: v2.5.3's CompressNR requests 192 vCPU, which only places on the r8g compress
+      # compute environment sized in this same change. Apply the CE and this pin together; a pin bump
+      # without the r8g CE would leave CompressNR unschedulable.
       #
       # v2.5.1 is skipped on purpose: v2.5.1-superkingdom is a hand-built overlay image, and an
       # adjacent v2.5.1 release tag would be easy to confuse with it.
-      INDEX_GENERATION_WORKFLOW_VERSION = "v2.5.2"
+      INDEX_GENERATION_WORKFLOW_VERSION = "v2.5.3"
       AWS_ACCOUNT_ID                    = var.AWS_ACCOUNT_ID
       # Per-stage container memory (MB) for the multi-stage pipeline (Lever 1, Track A).
       # Replaces the single MEMORY/VCPU override of the old monolith. VCPU is now set by

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -537,10 +537,20 @@ resource "aws_lambda_function" "start_index_generation" {
       # Per-stage container memory (MB) for the multi-stage pipeline (Lever 1, Track A).
       # Replaces the single MEMORY/VCPU override of the old monolith. VCPU is now set by
       # each stage's compute-environment instance family, not a container override.
-      DOWNLOAD_MEMORY     = "14000"  # c6i.2xlarge (16 GB), IO-bound download
-      COMPRESS_MEMORY     = "380000" # r6i.12xlarge (384 GB), ncbi-compress
-      INDEX_SPOT_MEMORY   = "128000" # index build on spot
-      INDEX_EC2_MEMORY    = "250000" # index build on the on-demand fallback
+      DOWNLOAD_MEMORY = "14000" # c6i.2xlarge (16 GB), IO-bound download
+      # Compress container memory (MB) -> emitted as CompressEC2Memory. Batch selects the compress
+      # instance by MEMORY (the job's vcpu request is 1; the container then uses all cores of the
+      # instance its memory footprint lands on), so this value is what steers the lane onto a given
+      # box. 1450000 (1450 GB) only fits r8g.48xlarge (1536 GB / 192 vCPU, 869 CE) -> the parallel-
+      # over-taxids NR compress runs across all 192 cores. r7g/r8g.12xlarge (384 GB) can no longer
+      # hold it, which is intended: the whole point of v2.5.3 is to stop pinning NR compress to 48
+      # cores. NOTE: this single knob feeds BOTH CompressNR and CompressNT, so CompressNT also
+      # requests 1450 GB and lands on r8g.48xlarge; with max_vcpus 256 the two Phase-2 lanes
+      # therefore serialize rather than run concurrently. Splitting into COMPRESS_NR_MEMORY /
+      # COMPRESS_NT_MEMORY (so NT keeps 384 GB and the lanes overlap) is a follow-up.
+      COMPRESS_MEMORY     = "1450000" # r8g.48xlarge (1536 GB / 192 vCPU), parallel ncbi-compress (869)
+      INDEX_SPOT_MEMORY   = "128000"  # index build on spot
+      INDEX_EC2_MEMORY    = "250000"  # index build on the on-demand fallback
       BUCKET              = data.aws_s3_bucket.public-references.bucket
       S3_WORKFLOWS_BUCKET = aws_s3_bucket.workflows.bucket
     }

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -101,16 +101,23 @@ locals {
     compress = {
       instance_types_x86      = ["r6i.32xlarge", "r6i.12xlarge"] # 128 vCPU / 1024 GB ; 48 / 384
       instance_types_graviton = ["r8g.48xlarge", "r8g.12xlarge"] # 192 vCPU / 1536 GB (Graviton4) ; 48 / 384
-      # Fan-out (800): CompressNR and CompressNT run CONCURRENTLY (Phase-2 lanes) on this one
-      # compute environment. Batch places each lane on the SMALLEST listed instance that fits its
-      # runtime request, so the two lanes size INDEPENDENTLY (869):
-      #   - CompressNR requests 192 vCPU / 1450 GB -> r8g.48xlarge (Graviton4). ncbi-compress now
-      #     parallelizes ACROSS taxids (per-taxid dedup is independent), so it scales with cores
-      #     instead of the old serial one-taxid-at-a-time loop that pinned 48 cores at 99% for
-      #     ~34 h on core_nt. The large RAM is what lets many taxid units run concurrently.
-      #   - CompressNT requests 48 vCPU / 384 GB   -> r8g.12xlarge. NT is I/O-bound (the EBS
-      #     override below is for it); more cores do nothing, so it stays small and cheap.
-      # max_vcpus must fit BOTH concurrently: NR(192) + NT(48) = 240, rounded to 256 for headroom.
+      # Fan-out (800): CompressNR and CompressNT are the two Phase-2 lanes, both submitted to this
+      # one compute environment. Batch selects the instance by the job's MEMORY request (the vcpu
+      # request is 1; the container then uses every core of the instance it lands on), and that
+      # memory comes from a SINGLE knob -- COMPRESS_MEMORY in the launcher lambda, emitted as
+      # CompressEC2Memory for BOTH lanes (869):
+      #   - COMPRESS_MEMORY = 1450000 (1450 GB) fits only r8g.48xlarge (1536 GB / 192 vCPU,
+      #     Graviton4). CompressNR runs there across all 192 cores: ncbi-compress now parallelizes
+      #     ACROSS taxids (per-taxid dedup is independent), so it scales with cores instead of the
+      #     old serial one-taxid-at-a-time loop that pinned 48 cores at 99% for ~34 h on core_nt.
+      #   - Because the knob is shared, CompressNT ALSO requests 1450 GB and lands on r8g.48xlarge
+      #     too. It is I/O-bound (the EBS override below is for it) and does not need the cores, so
+      #     this is wasteful, and with max_vcpus 256 the two lanes cannot both hold an r8g.48xlarge
+      #     (2 x 192 > 256) -- they SERIALIZE rather than overlap. Splitting the knob into
+      #     COMPRESS_NR_MEMORY / COMPRESS_NT_MEMORY (NT back to 384 GB -> r8g.12xlarge, lanes
+      #     overlap again) is a tracked follow-up; correctness holds without it.
+      # max_vcpus 256 holds one r8g.48xlarge (192) with headroom; raise it if the knob is split so
+      # NR(192) + NT(48) can run concurrently.
       max_vcpus  = 256
       scratch_gb = 4096
       # EBS PERFORMANCE OVERRIDE (compress only). ncbi-compress is the one index-generation

--- a/terraform/sfn_templates/index-generation.yml
+++ b/terraform/sfn_templates/index-generation.yml
@@ -205,7 +205,7 @@ States:
               Timeout: &CompressBatchTimeout
                 AttemptDurationSeconds: 172800 # 48 hours
               ContainerOverrides:
-                Memory.$: $.CompressEC2Memory
+                Memory.$: $.CompressNREC2Memory
                 Environment:
                   - Name: WDL_INPUT_URI
                     Value.$: $.COMPRESS_NR_INPUT_URI
@@ -274,7 +274,7 @@ States:
               JobDefinition: *JobDefinition
               Timeout: *CompressBatchTimeout
               ContainerOverrides:
-                Memory.$: $.CompressEC2Memory
+                Memory.$: $.CompressNTEC2Memory
                 Environment:
                   - Name: WDL_INPUT_URI
                     Value.$: $.COMPRESS_NT_INPUT_URI

--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -89,7 +89,13 @@ def start_index_generation(event, *args):
 
     # Per-stage container memory (MB). The SFN template reads these per lane/phase.
     download_memory = int(os.environ["DOWNLOAD_MEMORY"])
-    compress_memory = int(os.environ["COMPRESS_MEMORY"])
+    # CompressNR and CompressNT size independently (869): NR needs a 1450 GB box (r8g.48xlarge,
+    # 192 cores) for the parallel-over-taxids compress; NT is I/O-bound and stays on 384 GB
+    # (r8g.12xlarge). Batch selects the instance by the job's memory request, so these are two
+    # separate knobs -- a single shared value would force NT onto the big box and serialize the
+    # two Phase-2 lanes.
+    compress_nr_memory = int(os.environ["COMPRESS_NR_MEMORY"])
+    compress_nt_memory = int(os.environ["COMPRESS_NT_MEMORY"])
     index_spot_memory = int(os.environ["INDEX_SPOT_MEMORY"])
     index_ec2_memory = int(os.environ["INDEX_EC2_MEMORY"])
 
@@ -284,7 +290,8 @@ def start_index_generation(event, *args):
         "OutputPrefix": output_prefix,
         # Per-stage container memory overrides consumed by the SFN template.
         "DownloadEC2Memory": download_memory,
-        "CompressEC2Memory": compress_memory,
+        "CompressNREC2Memory": compress_nr_memory,
+        "CompressNTEC2Memory": compress_nt_memory,
         "IndexSPOTMemory": index_spot_memory,
         "IndexEC2Memory": index_ec2_memory,
     }

--- a/terraform/start_index_generation_lambda_src/test_main.py
+++ b/terraform/start_index_generation_lambda_src/test_main.py
@@ -46,7 +46,8 @@ os.environ.update({
     "BUCKET": "seqtoid-public-references",
     "S3_WORKFLOWS_BUCKET": "seqtoid-workflows-dev-491013321714",
     "DOWNLOAD_MEMORY": "14000",
-    "COMPRESS_MEMORY": "380000",
+    "COMPRESS_NR_MEMORY": "1450000",
+    "COMPRESS_NT_MEMORY": "380000",
     "INDEX_SPOT_MEMORY": "128000",
     "INDEX_EC2_MEMORY": "250000",
 })
@@ -75,7 +76,8 @@ expected_uri_keys = {
 }
 assert set(d) == expected_uri_keys | {
     "STAGES_IO_MAP_JSON", "Input", "OutputPrefix",
-    "DownloadEC2Memory", "CompressEC2Memory", "IndexSPOTMemory", "IndexEC2Memory",
+    "DownloadEC2Memory", "CompressNREC2Memory", "CompressNTEC2Memory",
+    "IndexSPOTMemory", "IndexEC2Memory",
 }, f"top-level keys: {sorted(d)}"
 assert d["DOWNLOAD_NR_WDL_URI"].endswith("index-generation-v2.4.8/download-nr.wdl")
 assert d["INDEX_NT_WDL_URI"].endswith("index-generation-v2.4.8/index-nt.wdl")
@@ -110,7 +112,8 @@ assert d["STAGES_IO_MAP_JSON"].endswith("2026-07-21/stage_io_map.json")
 
 # ---- memory overrides pass through ----
 assert d["DownloadEC2Memory"] == 14000
-assert d["CompressEC2Memory"] == 380000
+assert d["CompressNREC2Memory"] == 1450000
+assert d["CompressNTEC2Memory"] == 380000
 assert d["IndexSPOTMemory"] == 128000
 assert d["IndexEC2Memory"] == 250000
 

--- a/terraform/start_index_generation_lambda_src/test_main_lever4.py
+++ b/terraform/start_index_generation_lambda_src/test_main_lever4.py
@@ -57,7 +57,8 @@ os.environ.update({
     "BUCKET": "seqtoid-public-references",
     "S3_WORKFLOWS_BUCKET": "seqtoid-workflows-dev-491013321714",
     "DOWNLOAD_MEMORY": "14000",
-    "COMPRESS_MEMORY": "380000",
+    "COMPRESS_NR_MEMORY": "1450000",
+    "COMPRESS_NT_MEMORY": "380000",
     "INDEX_SPOT_MEMORY": "128000",
     "INDEX_EC2_MEMORY": "250000",
 })


### PR DESCRIPTION
Pairs with the parallel-over-taxids compress ([seqtoid-workflows #41](https://github.com/IT-Academic-Research-Services/seqtoid-workflows/pull/41)). NR compress was a ~34h single-instance grind: CPU-bound at 99% on r7g.12xlarge (48 vCPU), but the old serial taxid loop meant more cores barely helped. Now that the compress parallelizes across taxids, it scales with cores -- so the NR lane is sized up.

## Change

The compress compute environment offers **r8g.48xlarge (192 vCPU / 1536 GB)** and **r8g.12xlarge (48 / 384)**. Batch places each Phase-2 lane on the smallest instance that fits its runtime request, so they size **independently**:
- CompressNR (192 vCPU / 1450 GB) -> r8g.48xlarge
- CompressNT (48 / 384, I/O-bound) -> r8g.12xlarge (more cores do nothing for it)

`max_vcpus` -> 256 so both fit concurrently (192 + 48). The existing EBS-throughput override (for the I/O-bound NT lane) is unchanged and within r8g EBS bandwidth.

**Same arch** (arm64/Graviton) as the current r7g -- r8g runs the existing multi-arch image, no arch change here (the BLAST arch fix rides in the workflows PR).

## Deploy

Reviewer-gated `targeted-apply` (dev). The validation run tunes `COMPRESS_TAXID_CONCURRENCY` against measured peak memory before the full core_nt run. Expect adds/changes only (CE + launch template + queue max_vcpus) -- **no destroys** to confirm on the plan.