### PR TITLE
[ON-HOLD] perf(index-gen): launcher reuse levers -- default snapshot pin + reuse-as-default [HELD: sandbox-only]

### DIFF
--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -205,6 +205,19 @@ variable "use_graviton" {
   description = "Run index-generation Batch stages on Graviton3 (arm64). Default true; flip to false to fall back to Track A x86 per-stage families."
 }
 
+variable "index_gen_default_db_snapshot_prefix" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    Default DB snapshot pin for start_index_generation. An S3 key prefix (or full s3:// URI)
+    holding the pinned raw db fastas (<nt_database_type>.fsa.gz, nr.fsa.gz) and the five
+    DownloadTaxonomy source files. When set, a normal run reads these instead of fetching from
+    NCBI (skips the ~7.4h download); compress + index still rebuild from the snapshot. Empty
+    (the default) preserves live-NCBI behavior, so an environment is unchanged until its prefix
+    is set. An explicit live_ncbi_refresh=true on the run event forces the live path regardless.
+  EOT
+}
+
 data "aws_ssm_parameter" "idseq_batch_ami" {
   # NOTE: the mock-aws/aws conditional is because moto errors on creating ssm parameters that begin with aws or ssm.
   #
@@ -558,6 +571,9 @@ resource "aws_lambda_function" "start_index_generation" {
       INDEX_EC2_MEMORY    = "250000"  # index build on the on-demand fallback
       BUCKET              = data.aws_s3_bucket.public-references.bucket
       S3_WORKFLOWS_BUCKET = aws_s3_bucket.workflows.bucket
+      # Default DB snapshot pin (biggest re-run lever). Empty = live NCBI (current behavior);
+      # set per-environment to skip the ~7.4h fetch. See variable for the expected layout.
+      DEFAULT_DB_SNAPSHOT_PREFIX = var.index_gen_default_db_snapshot_prefix
     }
   }
 }

--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -218,6 +218,22 @@ variable "index_gen_default_db_snapshot_prefix" {
   EOT
 }
 
+variable "index_gen_default_refresh_scope" {
+  type        = string
+  default     = "full"
+  description = <<-EOT
+    Default refresh_scope for start_index_generation when the run event does not set one.
+    "full" (the default) rebuilds every DB. Set to "nt_only"/"nr_only"/"lineage_only" to make
+    whole-artifact reuse the default for cheap re-runs (an out-of-scope DB reuses the prior
+    run's compressed fasta and skips compression). dev stays "full" until this is set. An
+    explicit event refresh_scope always wins; live_ncbi_refresh=true forces "full".
+  EOT
+  validation {
+    condition     = contains(["full", "nt_only", "nr_only", "lineage_only"], var.index_gen_default_refresh_scope)
+    error_message = "index_gen_default_refresh_scope must be one of: full, nt_only, nr_only, lineage_only."
+  }
+}
+
 data "aws_ssm_parameter" "idseq_batch_ami" {
   # NOTE: the mock-aws/aws conditional is because moto errors on creating ssm parameters that begin with aws or ssm.
   #
@@ -574,6 +590,9 @@ resource "aws_lambda_function" "start_index_generation" {
       # Default DB snapshot pin (biggest re-run lever). Empty = live NCBI (current behavior);
       # set per-environment to skip the ~7.4h fetch. See variable for the expected layout.
       DEFAULT_DB_SNAPSHOT_PREFIX = var.index_gen_default_db_snapshot_prefix
+      # Default refresh_scope when the run event does not set one. "full" = rebuild every DB
+      # (current behavior); a scoped value makes whole-artifact reuse the default for re-runs.
+      DEFAULT_REFRESH_SCOPE = var.index_gen_default_refresh_scope
     }
   }
 }

--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -132,6 +132,22 @@ def start_index_generation(event, *args):
     # held taxonomy snapshot. When unset the taxonomy lane defaults to live NCBI FTP.
     taxonomy_snapshot_prefix = overrides.get("taxonomy_snapshot_prefix")
 
+    # Default DB snapshot pin (biggest re-run lever). Unless this run is an explicit live-NCBI
+    # refresh (the "annual full refresh" gate) or the caller passed explicit
+    # provided_*/taxonomy_snapshot_prefix, point the download + taxonomy lanes at a pinned S3
+    # snapshot so a normal run SKIPS the ~7.4h NCBI fetch (compress + index still rebuild from
+    # the snapshot fasta). The snapshot prefix is expected to hold the raw db fastas
+    # (<nt_database_type>.fsa.gz, nr.fsa.gz) and the five taxonomy files the DownloadTaxonomy
+    # WDL names. An EMPTY DEFAULT_DB_SNAPSHOT_PREFIX (the default) preserves live-NCBI behavior,
+    # so an environment is unchanged until its prefix is set -- dev stays on live NCBI until
+    # explicitly opted in. Set live_ncbi_refresh=true on the event to force the live path (and
+    # re-pin the snapshot out of band); that is the deliberate, expensive annual refresh.
+    default_snapshot_prefix = os.environ.get("DEFAULT_DB_SNAPSHOT_PREFIX", "").strip()
+    live_ncbi_refresh = bool(overrides.get("live_ncbi_refresh", False))
+    use_default_snapshot = bool(default_snapshot_prefix) and not live_ncbi_refresh
+    if use_default_snapshot and not taxonomy_snapshot_prefix:
+        taxonomy_snapshot_prefix = default_snapshot_prefix
+
     sfn = boto3.client("stepfunctions")
     s3 = boto3.client("s3")
 
@@ -193,13 +209,17 @@ def start_index_generation(event, *args):
     stage_io_map_key = f"ncbi-indexes-{deployment_environment}/{index_name}/stage_io_map.json"
     s3.put_object(Bucket=bucket, Key=stage_io_map_key, Body=json.dumps(STAGES_IO_MAP).encode())
 
-    def snapshot_uri(name):
-        """Resolve a taxonomy snapshot file: `taxonomy_snapshot_prefix` may be a full s3://
-        URI or a key prefix under the references bucket."""
-        prefix = taxonomy_snapshot_prefix.rstrip("/")
+    def snapshot_file_uri(prefix, name):
+        """Resolve a file under a snapshot prefix that may be a full s3:// URI or a key prefix
+        under the references bucket."""
+        prefix = prefix.rstrip("/")
         if prefix.startswith("s3://"):
             return f"{prefix}/{name}"
         return s3_uri(f"{prefix}/{name}")
+
+    def snapshot_uri(name):
+        """Resolve a taxonomy snapshot file under `taxonomy_snapshot_prefix`."""
+        return snapshot_file_uri(taxonomy_snapshot_prefix, name)
 
     # Per-stage inputs: ONLY each sub-WDL's declared workflow inputs. The File hand-offs are
     # injected at runtime via STAGES_IO_MAP, so they are omitted here.
@@ -260,6 +280,19 @@ def start_index_generation(event, *args):
     if not nr_in_scope and not provided_nr and previous_nr_compressed:
         download_nr_input["provided_nr"] = s3_uri(previous_nr_compressed)
         compress_nr_input["skip_protein_compression"] = True
+
+    # Default DB snapshot: for any DB lane NOT already pointed at an explicit override or a
+    # reused compressed artifact, read its raw fasta from the pinned snapshot instead of NCBI.
+    # This skips the fetch while still compressing + indexing from the snapshot fasta, so it is
+    # the safe default for a normal (non-annual) run. Precedence: explicit provided_* > scoped
+    # compressed reuse > default snapshot > live NCBI. Snapshot filenames mirror each lane's
+    # extracted db (<nt_database_type>.fsa.gz / nr.fsa.gz); provided_* accepts .gz and unzips.
+    if use_default_snapshot and "provided_nt" not in download_nt_input:
+        download_nt_input["provided_nt"] = snapshot_file_uri(
+            default_snapshot_prefix, f"{nt_database_type}.fsa.gz"
+        )
+    if use_default_snapshot and "provided_nr" not in download_nr_input:
+        download_nr_input["provided_nr"] = snapshot_file_uri(default_snapshot_prefix, "nr.fsa.gz")
 
     # Explicit compression-skip overrides take precedence over the refresh_scope default.
     if "skip_nuc_compression" in overrides:

--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -203,7 +203,13 @@ def start_index_generation(event, *args):
             ):
                 previous_nr_compressed = key
 
-    index_name = event["time"][:10]
+    # The output directory name under ncbi-indexes-<env>/. Defaults to the run date (a dated
+    # prefix, which the prior-run reuse discovery scans). An explicit index_name override lets a
+    # one-off run write to a NON-dated, isolated prefix (e.g. an optimized-version validation run
+    # whose output must stay invisible to normal runs' reuse discovery and must never be
+    # registered as a dev index). The override flows through to output_prefix + stage_io_map, so
+    # every stage output lands under it.
+    index_name = overrides.get("index_name") or event["time"][:10]
     docker_image_id = f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/index-generation:{version}"
     output_prefix = f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/"
 

--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -118,8 +118,17 @@ def start_index_generation(event, *args):
     provided_nt = overrides.get("provided_nt")
     nt_database_type = overrides.get("nt_database_type", "nt")
 
-    # Lever 4 (802) refresh_scope: which lanes do real work this run.
-    refresh_scope = overrides.get("refresh_scope", "full")
+    # Annual full-refresh gate: an explicit live NCBI refresh both fetches live AND rebuilds
+    # everything, so it forces refresh_scope=full (never an artifact-reuse skip).
+    live_ncbi_refresh = bool(overrides.get("live_ncbi_refresh", False))
+
+    # Lever 4 (802) refresh_scope: which lanes do real work this run. The default is env-gated
+    # (DEFAULT_REFRESH_SCOPE, default "full") so an environment can make whole-artifact reuse the
+    # default for cheap re-runs without a code change -- dev stays "full" until its env var is
+    # set. An explicit event refresh_scope always wins; live_ncbi_refresh forces "full".
+    refresh_scope = overrides.get("refresh_scope") or os.environ.get("DEFAULT_REFRESH_SCOPE", "full")
+    if live_ncbi_refresh:
+        refresh_scope = "full"
     valid_scopes = ("full", "nt_only", "nr_only", "lineage_only")
     if refresh_scope not in valid_scopes:
         raise ValueError(
@@ -143,7 +152,6 @@ def start_index_generation(event, *args):
     # explicitly opted in. Set live_ncbi_refresh=true on the event to force the live path (and
     # re-pin the snapshot out of band); that is the deliberate, expensive annual refresh.
     default_snapshot_prefix = os.environ.get("DEFAULT_DB_SNAPSHOT_PREFIX", "").strip()
-    live_ncbi_refresh = bool(overrides.get("live_ncbi_refresh", False))
     use_default_snapshot = bool(default_snapshot_prefix) and not live_ncbi_refresh
     if use_default_snapshot and not taxonomy_snapshot_prefix:
         taxonomy_snapshot_prefix = default_snapshot_prefix

--- a/terraform/start_index_generation_lambda_src/test_main_snapshot.py
+++ b/terraform/start_index_generation_lambda_src/test_main_snapshot.py
@@ -172,4 +172,14 @@ assert "skip_nuc_compression" not in inp["CompressNT"]
 os.environ.pop("DEFAULT_REFRESH_SCOPE", None)
 os.environ.pop("DEFAULT_DB_SNAPSHOT_PREFIX", None)
 
+# ==== index_name override (isolated non-dated output prefix) ====
+# default: dated prefix from the event time
+inp = run(None)
+assert captured["sfn_input"]["OutputPrefix"].endswith("/ncbi-indexes-dev/2026-07-23/"), \
+    captured["sfn_input"]["OutputPrefix"]
+# override: a non-dated isolated prefix (invisible to prior-run reuse discovery)
+run(None, {"index_name": "optimized-fanout-4bd5413"})
+assert captured["sfn_input"]["OutputPrefix"] == \
+    f"{_BASE}/ncbi-indexes-dev/optimized-fanout-4bd5413/", captured["sfn_input"]["OutputPrefix"]
+
 print("ALL SNAPSHOT ASSERTIONS PASSED")

--- a/terraform/start_index_generation_lambda_src/test_main_snapshot.py
+++ b/terraform/start_index_generation_lambda_src/test_main_snapshot.py
@@ -1,0 +1,129 @@
+"""Default DB snapshot pin tests for start_index_generation.
+
+Exercises DEFAULT_DB_SNAPSHOT_PREFIX: a normal run points the download + taxonomy lanes at a
+pinned S3 snapshot (skip the ~7.4h NCBI fetch); live_ncbi_refresh=true forces live NCBI (the
+annual gate); explicit provided_* and scoped compressed-reuse take precedence over the
+snapshot; an empty prefix preserves live-NCBI behavior. No AWS.
+"""
+import json
+import os
+import sys
+import types
+
+captured = {"sfn_input": None, "put_objects": []}
+
+_PRIOR = "ncbi-indexes-dev/2026-07-09/index-generation-2"
+_PRIOR_KEYS = [
+    f"{_PRIOR}/nt_compressed.fa",
+    f"{_PRIOR}/nr_compressed.fa",
+    f"{_PRIOR}/versioned-taxid-lineages.csv.gz",
+]
+
+
+class FakePaginator:
+    def paginate(self, **kw):
+        return [{"Contents": [{"Key": k} for k in _PRIOR_KEYS]}]
+
+
+class FakeS3:
+    def get_paginator(self, name):
+        return FakePaginator()
+
+    def put_object(self, **kw):
+        captured["put_objects"].append(kw)
+
+
+class FakeSFN:
+    def start_execution(self, **kw):
+        captured["sfn_input"] = json.loads(kw["input"])
+
+
+fake_boto3 = types.ModuleType("boto3")
+fake_boto3.client = lambda svc: FakeSFN() if svc == "stepfunctions" else FakeS3()
+sys.modules["boto3"] = fake_boto3
+
+os.environ.update({
+    "DEPLOYMENT_ENVIRONMENT": "dev",
+    "INDEX_GENERATION_SFN_ARN":
+        "arn:aws:states:us-west-2:491013321714:stateMachine:idseq-swipe-dev-index-generation-wdl",
+    "INDEX_GENERATION_WORKFLOW_VERSION": "v2.4.8",
+    "AWS_REGION": "us-west-2",
+    "AWS_ACCOUNT_ID": "491013321714",
+    "BUCKET": "seqtoid-public-references",
+    "S3_WORKFLOWS_BUCKET": "seqtoid-workflows-dev-491013321714",
+    "DOWNLOAD_MEMORY": "14000",
+    "COMPRESS_NR_MEMORY": "1450000",
+    "COMPRESS_NT_MEMORY": "380000",
+    "INDEX_SPOT_MEMORY": "128000",
+    "INDEX_EC2_MEMORY": "250000",
+})
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import main  # noqa: E402
+
+_BASE = "s3://seqtoid-public-references"
+_SNAP = "ncbi-indexes-dev/db-snapshots/2026-07-09"
+_SNAP_URI = f"{_BASE}/{_SNAP}"
+
+
+def run(snapshot_prefix=None, ig=None):
+    if snapshot_prefix is None:
+        os.environ.pop("DEFAULT_DB_SNAPSHOT_PREFIX", None)
+    else:
+        os.environ["DEFAULT_DB_SNAPSHOT_PREFIX"] = snapshot_prefix
+    captured["sfn_input"] = None
+    main.start_index_generation({"time": "2026-07-23T08:00:00Z", "index_generation": ig or {}})
+    return captured["sfn_input"]["Input"]
+
+
+# ---- no prefix (default): live NCBI, unchanged behavior ----
+inp = run(None)
+assert "provided_nt" not in inp["DownloadNT"], "no snapshot: NT must download live"
+assert "provided_nr" not in inp["DownloadNR"], "no snapshot: NR must download live"
+assert "provided_taxdump" not in inp["DownloadTaxonomy"], "no snapshot: taxonomy live"
+
+# ---- snapshot set (normal run): all three lanes read the snapshot, skip download ----
+inp = run(_SNAP)
+assert inp["DownloadNT"]["provided_nt"] == f"{_SNAP_URI}/nt.fsa.gz", inp["DownloadNT"]
+assert inp["DownloadNR"]["provided_nr"] == f"{_SNAP_URI}/nr.fsa.gz", inp["DownloadNR"]
+assert inp["DownloadTaxonomy"]["provided_taxdump"] == f"{_SNAP_URI}/taxdump.tar.gz"
+assert inp["DownloadTaxonomy"]["provided_accession2taxid_prot"] == \
+    f"{_SNAP_URI}/prot.accession2taxid.FULL.gz"
+# compression still runs from the snapshot fasta (this is not a compressed-artifact reuse)
+assert "skip_nuc_compression" not in inp["CompressNT"]
+assert "skip_protein_compression" not in inp["CompressNR"]
+
+# ---- core_nt: the nt snapshot filename tracks nt_database_type ----
+inp = run(_SNAP, {"nt_database_type": "core_nt"})
+assert inp["DownloadNT"]["provided_nt"] == f"{_SNAP_URI}/core_nt.fsa.gz", inp["DownloadNT"]
+
+# ---- annual gate: live_ncbi_refresh=true bypasses the snapshot entirely ----
+inp = run(_SNAP, {"live_ncbi_refresh": True})
+assert "provided_nt" not in inp["DownloadNT"], "live_ncbi_refresh: NT must fetch live"
+assert "provided_nr" not in inp["DownloadNR"], "live_ncbi_refresh: NR must fetch live"
+assert "provided_taxdump" not in inp["DownloadTaxonomy"], "live_ncbi_refresh: taxonomy live"
+
+# ---- explicit provided_* wins over the snapshot default ----
+inp = run(_SNAP, {"provided_nt": "s3://x/my_nt.fsa"})
+assert inp["DownloadNT"]["provided_nt"] == "s3://x/my_nt.fsa", "explicit provided_nt must win"
+assert inp["DownloadNR"]["provided_nr"] == f"{_SNAP_URI}/nr.fsa.gz", "nr still snapshot"
+
+# ---- explicit taxonomy_snapshot_prefix wins over the DB snapshot default for taxonomy ----
+inp = run(_SNAP, {"taxonomy_snapshot_prefix": "s3://other/tax/"})
+assert inp["DownloadTaxonomy"]["provided_taxdump"] == "s3://other/tax/taxdump.tar.gz"
+# db lanes still take the DB snapshot
+assert inp["DownloadNT"]["provided_nt"] == f"{_SNAP_URI}/nt.fsa.gz"
+
+# ---- scoped compressed reuse beats the snapshot for an out-of-scope DB ----
+# nr_only: NR in scope -> snapshot raw; NT out of scope -> reuse prior COMPRESSED + skip compress.
+inp = run(_SNAP, {"refresh_scope": "nr_only"})
+assert inp["DownloadNT"]["provided_nt"] == f"{_BASE}/{_PRIOR}/nt_compressed.fa", \
+    "out-of-scope NT must reuse compressed, not snapshot"
+assert inp["CompressNT"]["skip_nuc_compression"] is True
+assert inp["DownloadNR"]["provided_nr"] == f"{_SNAP_URI}/nr.fsa.gz", "in-scope NR uses snapshot"
+assert "skip_protein_compression" not in inp["CompressNR"]
+
+# ---- snapshot prefix given as a bare key (not s3://) resolves under the references bucket ----
+inp = run("ncbi-indexes-dev/db-snapshots/2026-07-09")
+assert inp["DownloadNR"]["provided_nr"] == f"{_BASE}/{_SNAP}/nr.fsa.gz"
+
+print("ALL SNAPSHOT ASSERTIONS PASSED")

--- a/terraform/start_index_generation_lambda_src/test_main_snapshot.py
+++ b/terraform/start_index_generation_lambda_src/test_main_snapshot.py
@@ -126,4 +126,50 @@ assert "skip_protein_compression" not in inp["CompressNR"]
 inp = run("ncbi-indexes-dev/db-snapshots/2026-07-09")
 assert inp["DownloadNR"]["provided_nr"] == f"{_BASE}/{_SNAP}/nr.fsa.gz"
 
+# ==== DEFAULT_REFRESH_SCOPE (reuse-as-default) ====
+_PRIOR_NT_C = f"{_BASE}/{_PRIOR}/nt_compressed.fa"
+_PRIOR_NR_C = f"{_BASE}/{_PRIOR}/nr_compressed.fa"
+
+
+def run_scope(default_scope=None, ig=None, snapshot=None):
+    if default_scope is None:
+        os.environ.pop("DEFAULT_REFRESH_SCOPE", None)
+    else:
+        os.environ["DEFAULT_REFRESH_SCOPE"] = default_scope
+    if snapshot is None:
+        os.environ.pop("DEFAULT_DB_SNAPSHOT_PREFIX", None)
+    else:
+        os.environ["DEFAULT_DB_SNAPSHOT_PREFIX"] = snapshot
+    captured["sfn_input"] = None
+    main.start_index_generation({"time": "2026-07-23T08:00:00Z", "index_generation": ig or {}})
+    return captured["sfn_input"]["Input"]
+
+
+# default scope full (unset env): full rebuild, no reuse
+inp = run_scope(None)
+assert "provided_nt" not in inp["DownloadNT"] and "provided_nr" not in inp["DownloadNR"]
+assert "skip_nuc_compression" not in inp["CompressNT"]
+
+# env default lineage_only: BOTH DBs reuse prior compressed + skip compression by default
+inp = run_scope("lineage_only")
+assert inp["DownloadNT"]["provided_nt"] == _PRIOR_NT_C, inp["DownloadNT"]
+assert inp["DownloadNR"]["provided_nr"] == _PRIOR_NR_C
+assert inp["CompressNT"]["skip_nuc_compression"] is True
+assert inp["CompressNR"]["skip_protein_compression"] is True
+
+# explicit event refresh_scope wins over the env default
+inp = run_scope("lineage_only", {"refresh_scope": "full"})
+assert "provided_nt" not in inp["DownloadNT"], "explicit full must override env default"
+assert "skip_nuc_compression" not in inp["CompressNT"]
+
+# live_ncbi_refresh forces full even if the env default is a reuse scope (annual gate)
+inp = run_scope("lineage_only", {"live_ncbi_refresh": True})
+assert "provided_nt" not in inp["DownloadNT"], "live_ncbi_refresh must force full rebuild"
+assert "provided_nr" not in inp["DownloadNR"]
+assert "skip_nuc_compression" not in inp["CompressNT"]
+
+# reset env so nothing leaks
+os.environ.pop("DEFAULT_REFRESH_SCOPE", None)
+os.environ.pop("DEFAULT_DB_SNAPSHOT_PREFIX", None)
+
 print("ALL SNAPSHOT ASSERTIONS PASSED")


### PR DESCRIPTION
## What (two launcher-side reuse levers; both env-gated, dev unchanged by default)

Stacked on #63 (r8g compress CE). Held for the sandbox validation run.

**A. Default DB snapshot pin** (`DEFAULT_DB_SNAPSHOT_PREFIX`, default `""`). When set, a normal
run points the download + taxonomy lanes at a pinned S3 snapshot (raw db fastas + the five
DownloadTaxonomy files) instead of NCBI, skipping the ~7.4h fetch; compress + index still
rebuild from the snapshot fasta. `live_ncbi_refresh=true` on the run event is the explicit
"annual full refresh" gate that forces live NCBI.

**C. Env-gated default `refresh_scope`** (`DEFAULT_REFRESH_SCOPE`, default `"full"`). Lets an
environment make whole-artifact reuse the default for cheap re-runs (an out-of-scope DB reuses
the prior compressed fasta and skips compression). An explicit event `refresh_scope` wins;
`live_ncbi_refresh` forces `"full"`.

Precedence for a DB lane: explicit `provided_*` > scoped compressed reuse > default snapshot >
live NCBI.

## Why safe for dev

Both knobs default to the CURRENT behavior (empty prefix = live NCBI; scope = full rebuild),
so applying this to dev changes nothing until dev's tfvars set them. The sandbox sets them to
enable reuse. No dev index is cut from this without explicit approval.

## Impact

Turns the fresh ~12-14h run into ~5-6h for a normal re-run (snapshot skips download), or ~2-3h
when the default scope also reuses compressed artifacts. Re-runs are the common dev case.

## Tests

`test_main_snapshot.py` (new): default-off, snapshot-on for nt/nr/taxonomy, core_nt filename,
the `live_ncbi_refresh` gate, explicit-override precedence, out-of-scope compressed-reuse
beating the snapshot, and the `DEFAULT_REFRESH_SCOPE` cases. Existing `test_main_lever4.py` +
`test_main.py` still pass. `terraform fmt` clean.

## Follow-on (NOT in this PR)

FJ#870 (compress call-cache busts on image bumps) is a swipe-fork cache-key change (governed,
needs the fork + sign-off). The reuse paths here already mitigate its practical impact -- they
skip the compress task outright, so they never depend on the call-cache.
