### PR TITLE
ci: repoint CI SSOT to IT-ARS (@v1) (CI v2 P1)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,9 +41,9 @@ jobs:
           pip-install: -r requirements-dev.txt
       - name: Run flake8
         # Our modernized flake8-action (upstream julianwachholz is node16/EOL), now living in
-        # thorvath-slower/seqtoid-ci-workflows (collapsed in from the standalone flake8-action repo).
+        # IT-Academic-Research-Services/seqtoid-ci-workflows (collapsed in from the standalone flake8-action repo).
         # Pinned to the seqtoid-ci-workflows @v1 moving major tag (SSOT: update once, propagates). See CZID-204 / #405 / #406.
-        uses: thorvath-slower/seqtoid-ci-workflows/flake8-action@v1
+        uses: IT-Academic-Research-Services/seqtoid-ci-workflows/flake8-action@v1
         with:
           checkName: "Python Lint"
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,6 @@
 name: security
 
-# Calls the shared reusable security workflow — the SSOT in thorvath-slower/seqtoid-ci-workflows (CZID-310).
+# Calls the shared reusable security workflow — the SSOT in IT-Academic-Research-Services/seqtoid-ci-workflows (CZID-310).
 # One definition for all repos; this repo only keeps its own .trivyignore baseline (CZID-264) and passes
 # its codegen as `prepare` so the IaC scanners see the complete config (this repo generates config from
 # the lambda packaging step).
@@ -20,7 +20,7 @@ jobs:
     # CZID-433 (F5b): repointed off the archived ci-workflows predecessor's mutable branch ref to the
     # current SSOT tag. The checkov_baseline/checkov_soft_fail inputs were ported into v1 (CZID-416), so
     # the @v1 reusable interface now accepts everything this caller passes.
-    uses: thorvath-slower/seqtoid-ci-workflows/.github/workflows/security.yml@v1
+    uses: IT-Academic-Research-Services/seqtoid-ci-workflows/.github/workflows/security.yml@v1
     with:
       run_checkov: true                   # checkov is now a GATE on every run (was workflow_dispatch-only)
       checkov_soft_fail: false            # hard-fail on findings NOT in the baseline

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,6 @@
 name: Terraform Validate
 
-# Thin caller of the SSOT reusable (thorvath-slower/seqtoid-ci-workflows) pinned @v1 — one definition,
+# Thin caller of the SSOT reusable (IT-Academic-Research-Services/seqtoid-ci-workflows) pinned @v1 — one definition,
 # updated once, used everywhere. This repo needs chalice lambda codegen + env sourcing before validate,
 # expressed via `prepare` + `validate_command`. Terraform version comes from .terraform-version.
 on:
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   validate:
-    uses: thorvath-slower/seqtoid-ci-workflows/.github/workflows/terraform-ci.yml@v1
+    uses: IT-Academic-Research-Services/seqtoid-ci-workflows/.github/workflows/terraform-ci.yml@v1
     with:
       fmt_path: "."
       # codegen (runs after fmt, before validate) — chalice lambda packaging + test env


### PR DESCRIPTION
CI v2 P1. Canonical CI SSOT = IT-Academic-Research-Services/seqtoid-ci-workflows (internal, org Actions-access enabled). Repoints `uses:` refs to @v1. terraform-plan-on-PR adoption follows.