### PR TITLE
ci: terraform plan-on-PR via plan_only (dev-plan environment)

### DIFF
--- a/.github/workflows/plan_call.yml
+++ b/.github/workflows/plan_call.yml
@@ -7,6 +7,14 @@ on:
         description: Both Github Environment and AWS Environment
         type: string
         required: true
+      github_environment:
+        description: >-
+          GitHub Environment to run under (overrides `environment` for the job's environment: key
+          only; the AWS env name still comes from `environment`). Used to route dev PR plans through
+          the all-branches `dev-plan` environment so the feature-branch gate doesn't block them.
+        type: string
+        required: false
+        default: ''
       targets:
         description: >-
           Optional space-separated terraform resource addresses. When set, the plan is limited to
@@ -29,7 +37,10 @@ env:
 jobs:
   plan:
     name: Plan
-    environment: ${{ inputs.environment }}
+    # github_environment (when set) overrides only the GitHub Environment the job runs under, so the
+    # OIDC sub becomes `...:environment:dev-plan` for PR plans (the plan role denies `:pull_request`).
+    # The AWS env name (role, profile, `source environment.<env>`) still comes from inputs.environment.
+    environment: ${{ inputs.github_environment != '' && inputs.github_environment || inputs.environment }}
     runs-on: ubuntu-latest
     env:
       AWS_REGION: us-west-2

--- a/.github/workflows/plan_only.yml
+++ b/.github/workflows/plan_only.yml
@@ -2,10 +2,20 @@ name: Plan only
 run-name: Plan only in env ${{ inputs.environment || github.base_ref || github.ref_name }} branch ${{ github.base_ref || github.ref_name }} by ${{ github.actor }}
 
 on:
-  # Planning assumes an AWS OIDC role (czid-<env>-gh-actions-plan) and reads
-  # the real S3 backend, so it can't run until GitHub Environments + OIDC roles
-  # exist (CZID-81 / CZID-26). Until then it is manual-only; the no-AWS
-  # validate.yml is the automatic push/PR gate.
+  # Planning assumes an AWS OIDC role (czid-<env>-gh-actions-plan) and reads the real S3 backend.
+  # The CZID-81/26 precondition (per-env OIDC trust + GitHub Environments) is now met, so an
+  # automatic dev plan-on-PR runs alongside manual dispatch: a PR touching infra runs a read-only
+  # dev plan routed through the all-branches `dev-plan` environment (the plan role denies the
+  # `:pull_request` OIDC sub) and reports change counts before merge. The no-AWS validate.yml
+  # remains the fmt/validate gate.
+  pull_request:
+    paths:
+      - '**.tf'
+      - '.terraform.lock.hcl'
+      - 'lambdas/**'
+      - 'glue_jobs/**'
+      - 'environment*'
+      - 'Makefile'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +59,11 @@ jobs:
           echo "environment=${{ inputs.environment }}"
           echo "| Planning | Environment | Branch |" >> "$GITHUB_STEP_SUMMARY"
           echo "| ---------------- | ----------- | ------ |" >> "$GITHUB_STEP_SUMMARY"
-          if [[ -n "${{ inputs.environment }}" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # PR plan-on-review is dev-only (staging/prod stay gated); routed via dev-plan below.
+            echo "environment=dev" >> "$GITHUB_OUTPUT"
+            echo "| :green_circle: Enabled | dev (PR) | ${{ env.branch_name }} |" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ -n "${{ inputs.environment }}" ]]; then
             echo "environment=${{ inputs.environment }}" >> "$GITHUB_OUTPUT"
             echo "| :green_circle: Enabled | ${{ inputs.environment }} | ${{ env.branch_name }} |" >> "$GITHUB_STEP_SUMMARY"
           elif [[ "${{ env.branch_name }}" == "development" ]]; then
@@ -74,6 +88,10 @@ jobs:
     uses: ./.github/workflows/plan_call.yml
     with:
       environment: ${{ needs.should-plan.outputs.environment }}
+      # On a dev PR from a feature branch, run under the all-branches dev-plan environment (the
+      # `dev` env's main-only deploy-branch policy would block the plan); on main/dispatch, empty
+      # -> plan_call falls back to the env's own GitHub Environment. staging/prod unaffected.
+      github_environment: ${{ (needs.should-plan.outputs.environment == 'dev' && github.ref_name != 'main') && 'dev-plan' || '' }}
       targets: ${{ inputs.targets }}
     secrets: inherit
 


### PR DESCRIPTION
Enables plan-on-PR for dev by turning on the existing plan_only orchestrator for pull_request (infra paths), resolving environment=dev and routing through the all-branches dev-plan GitHub Environment. Adds a github_environment input to plan_call (overrides only the job environment; AWS env unchanged). Same Option-A pattern as cypherid-web-infra #194. Uses the shared czid-dev-gh-actions-plan role (workflow-infra is in its trust), make package-lambdas codegen, and secrets: inherit. Validates after merge (pull_request runs from the base-branch definition).