### PR TITLE
index-generation: single-SSOT version coupling + fail-closed preflight (SMP-1463)

### DIFF
--- a/terraform/index-generation.tf
+++ b/terraform/index-generation.tf
@@ -455,6 +455,25 @@ resource "aws_iam_role_policy" "start_index_generation_lambda" {
         Resource : "arn:aws:s3:::seqtoid-public-references/ncbi-indexes-${var.DEPLOYMENT_ENVIRONMENT}/*",
       },
       {
+        # SMP-1463 preflight: list the versioned WDL prefix on the workflows bucket to confirm
+        # all 9 fan-out sub-WDLs for the pinned INDEX_GENERATION_WORKFLOW_VERSION were published
+        # before StartExecution. Bucket-level ListBucket only (no object read needed).
+        Effect : "Allow",
+        Action : [
+          "s3:ListBucket",
+        ],
+        Resource : aws_s3_bucket.workflows.arn,
+      },
+      {
+        # SMP-1463 preflight: confirm the ECR image tag for the pinned version exists before
+        # StartExecution. DescribeImages is read-only and scoped to the index-generation repo.
+        Effect : "Allow",
+        Action : [
+          "ecr:DescribeImages",
+        ],
+        Resource : "arn:aws:ecr:us-west-2:${var.AWS_ACCOUNT_ID}:repository/index-generation",
+      },
+      {
         Effect : "Allow",
         Action : [
           "logs:CreateLogGroup",
@@ -504,7 +523,11 @@ resource "aws_lambda_function" "start_index_generation" {
       # index-generation:<VER>. Bump all three together when releasing a new index-gen version.
       # v2.5.2 -- the first index-generation release built from source by CI rather than by hand.
       # This one variable is the SSOT for BOTH the ECR image tag (index-generation:<version>) and the
-      # S3 WDL prefix (index-generation-<version>/), so both must exist before it is bumped. Both do:
+      # S3 WDL prefix (index-generation-<version>/), so both must exist before it is bumped. The
+      # start_index_generation lambda now enforces this at runtime (SMP-1463): a preflight verifies
+      # the WDL prefix (all 9 sub-WDLs) and the ECR tag exist and fails closed BEFORE StartExecution,
+      # so a bump to a version whose artifacts are missing is rejected instead of dying inside SWIPE.
+      # Both currently exist:
       #   ECR  index-generation:v2.5.2 -> sha256:2c98beb6f1eb36ad3f3458f99236827db8fa198a713bd844ddce4fae1ff29d88
       #        multi-arch (linux/amd64 + linux/arm64); the arm64 entry is what the Graviton compress
       #        nodes actually execute. Same digest as the CI build c5ffdf7 -- retagged, not rebuilt.

--- a/terraform/start_index_generation_lambda_src/main.py
+++ b/terraform/start_index_generation_lambda_src/main.py
@@ -42,6 +42,68 @@ STAGE_WDL_FILENAMES = {
     "Assemble": "assemble.wdl",
 }
 
+# ---------------------------------------------------------------------------
+# Version SSOT (SMP-1463 / platform-overhaul 843).
+#
+# The index-generation workflow version is pinned in exactly ONE place: the terraform lambda
+# env INDEX_GENERATION_WORKFLOW_VERSION. Everything the pipeline pins to that version is
+# DERIVED from it HERE, so the three coupled artifacts can never drift apart:
+#   * the S3 WDL prefix   s3://<workflows>/index-generation-<VER>/   (all 9 fan-out sub-WDLs)
+#   * the ECR image tag   <acct>.dkr.ecr.<region>.amazonaws.com/index-generation:<VER>
+#   * the lambda env var  INDEX_GENERATION_WORKFLOW_VERSION          (the SSOT itself)
+#
+# WORKFLOW_NAME is the single token shared by the ECR repository name and the S3 WDL prefix, so
+# those cannot drift from each other either. wdl_prefix() / build_image_id() are the ONLY
+# builders of those strings -- both the run input (wdl_uri / per-stage docker_image_id) and the
+# preflight below go through them, so a check and the value it guards can never disagree.
+WORKFLOW_NAME = "index-generation"
+
+
+def wdl_prefix(version):
+    """S3 key prefix (no bucket, no trailing slash) holding the fan-out sub-WDLs for `version`."""
+    return f"{WORKFLOW_NAME}-{version}"
+
+
+def build_image_id(aws_account_id, aws_region, version):
+    """Fully-qualified ECR image reference for `version` (single definition)."""
+    return f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/{WORKFLOW_NAME}:{version}"
+
+
+def preflight_artifacts_exist(s3, ecr, workflows_bucket, aws_account_id, aws_region, version):
+    """Fail closed if the artifacts the pinned version points at do not exist.
+
+    The version SSOT (INDEX_GENERATION_WORKFLOW_VERSION) can name a version whose WDLs were
+    never published or whose image was never built -- exactly the v2.4.4 dangling-pointer state
+    SMP-1463 was opened for. Left unchecked, StartExecution succeeds and the run only dies deep
+    inside SWIPE with an opaque "object not found". Verify the S3 WDL prefix (all nine sub-WDLs)
+    and the ECR image tag up front so a misconfigured version is rejected before any execution
+    starts, with a message that names the SSOT env var.
+    """
+    missing = []
+
+    prefix = wdl_prefix(version)
+    resp = s3.list_objects_v2(Bucket=workflows_bucket, Prefix=f"{prefix}/")
+    present = {obj["Key"] for obj in resp.get("Contents", [])}
+    for filename in sorted(STAGE_WDL_FILENAMES.values()):
+        key = f"{prefix}/{filename}"
+        if key not in present:
+            missing.append(f"s3://{workflows_bucket}/{key}")
+
+    image = build_image_id(aws_account_id, aws_region, version)
+    try:
+        ecr.describe_images(repositoryName=WORKFLOW_NAME, imageIds=[{"imageTag": version}])
+    except ecr.exceptions.ImageNotFoundException:
+        missing.append(image)
+
+    if missing:
+        raise RuntimeError(
+            f"index-generation version {version!r} (INDEX_GENERATION_WORKFLOW_VERSION) points "
+            "at artifacts that do not exist; publish the WDLs and build/push the image for this "
+            "version, or pin a version whose artifacts exist, before invoking. Missing: "
+            + ", ".join(missing)
+        )
+
+
 # DAG output->input handoff map consumed by the io-helper. For each stage,
 # `{ <this stage's declared File input>: <accumulated output name to resolve it from> }`.
 # Sources are resolved from the run's accumulated Result (union of every completed stage's
@@ -128,6 +190,13 @@ def start_index_generation(event, *args):
 
     sfn = boto3.client("stepfunctions")
     s3 = boto3.client("s3")
+    ecr = boto3.client("ecr")
+
+    # SMP-1463: reject a version whose WDL prefix or image was never published BEFORE any
+    # StartExecution, so an invoke can never point at a missing artifact (the v2.4.4 state).
+    preflight_artifacts_exist(
+        s3, ecr, workflows_bucket, aws_account_id, aws_region, version
+    )
 
     # Discover the most recent prior run's artifacts. Used for (a) the taxonomy lineage
     # incremental build and (b) the Lever 4 refresh_scope reuse path, where an out-of-scope DB
@@ -174,11 +243,11 @@ def start_index_generation(event, *args):
                 previous_nr_compressed = key
 
     index_name = event["time"][:10]
-    docker_image_id = f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/index-generation:{version}"
+    docker_image_id = build_image_id(aws_account_id, aws_region, version)
     output_prefix = f"s3://{bucket}/ncbi-indexes-{deployment_environment}/{index_name}/"
 
     def wdl_uri(stage):
-        return f"s3://{workflows_bucket}/index-generation-{version}/{STAGE_WDL_FILENAMES[stage]}"
+        return f"s3://{workflows_bucket}/{wdl_prefix(version)}/{STAGE_WDL_FILENAMES[stage]}"
 
     def s3_uri(key):
         return f"s3://{bucket}/{key}"
@@ -290,7 +359,7 @@ def start_index_generation(event, *args):
     }
     sfn.start_execution(
         stateMachineArn=state_machine_arn,
-        name=f"index-generation-{index_name}-{uuid4()}",
+        name=f"{WORKFLOW_NAME}-{index_name}-{uuid4()}",
         input=json.dumps(input_dict),
     )
 

--- a/terraform/start_index_generation_lambda_src/test_main.py
+++ b/terraform/start_index_generation_lambda_src/test_main.py
@@ -12,17 +12,40 @@ import types
 captured = {"sfn_input": None, "put_objects": []}
 
 
+# The nine fan-out sub-WDLs the SMP-1463 preflight requires under the versioned S3 prefix.
+_WDL_FILENAMES = [
+    "download-taxonomy.wdl", "download-nt.wdl", "download-nr.wdl",
+    "compress-nt.wdl", "compress-nr.wdl",
+    "index-nt.wdl", "index-nr.wdl", "index-taxonomy.wdl", "assemble.wdl",
+]
+
+
 class FakePaginator:
     def paginate(self, **kw):
         return [{"Contents": []}]  # no prior lineages / compressed dbs
 
 
+class _ECRExceptions:
+    class ImageNotFoundException(Exception):
+        pass
+
+
 class FakeS3:
+    # Serves both the s3 and ecr clients (fake_boto3.client returns this for either).
+    exceptions = _ECRExceptions
+
     def get_paginator(self, name):
         return FakePaginator()
 
     def put_object(self, **kw):
         captured["put_objects"].append(kw)
+
+    def list_objects_v2(self, Bucket, Prefix, **kw):
+        # SMP-1463 preflight: report all nine sub-WDLs published under the versioned prefix.
+        return {"Contents": [{"Key": Prefix + fn} for fn in _WDL_FILENAMES]}
+
+    def describe_images(self, **kw):
+        return {"imageDetails": [{"imageTags": [kw["imageIds"][0]["imageTag"]]}]}
 
 
 class FakeSFN:
@@ -113,5 +136,43 @@ assert d["DownloadEC2Memory"] == 14000
 assert d["CompressEC2Memory"] == 380000
 assert d["IndexSPOTMemory"] == 128000
 assert d["IndexEC2Memory"] == 250000
+
+# ---- SMP-1463 version SSOT: WDL prefix + ECR tag + exec name all derive from one version ----
+# The WDL prefix and the image tag are the same string in both the run input and the preflight,
+# so a run can never be started against a version whose artifacts the preflight did not verify.
+assert main.wdl_prefix("v2.4.8") == "index-generation-v2.4.8"
+assert main.build_image_id("491013321714", "us-west-2", "v2.4.8") == _image
+assert captured["exec_name"].startswith("index-generation-2026-07-21-")
+
+# ---- SMP-1463 preflight: fail closed when the pinned version's artifacts do not exist ----
+# This is the v2.4.4 dangling-pointer state the ticket was opened for -- the lambda must reject
+# it up front (naming the SSOT env var), not let StartExecution point at a missing artifact.
+
+
+class _Absent:
+    exceptions = _ECRExceptions
+
+    def list_objects_v2(self, Bucket, Prefix, **kw):
+        return {}  # no WDLs published under this prefix
+
+    def describe_images(self, **kw):
+        raise _ECRExceptions.ImageNotFoundException("not found")
+
+
+try:
+    main.preflight_artifacts_exist(
+        _Absent(), _Absent(), "wf-bucket", "491013321714", "us-west-2", "v9.9.9"
+    )
+    raise SystemExit("FAIL: preflight accepted a version with no artifacts")
+except RuntimeError as e:
+    msg = str(e)
+    assert "INDEX_GENERATION_WORKFLOW_VERSION" in msg, msg
+    assert "index-generation-v9.9.9/download-nr.wdl" in msg, msg
+    assert "index-generation:v9.9.9" in msg, msg
+
+# ---- preflight passes cleanly when every artifact exists (the FakeS3 happy path) ----
+main.preflight_artifacts_exist(
+    FakeS3(), FakeS3(), "wf-bucket", "491013321714", "us-west-2", "v2.4.8"
+)
 
 print("\nALL ASSERTIONS PASSED")

--- a/terraform/start_index_generation_lambda_src/test_main_lever4.py
+++ b/terraform/start_index_generation_lambda_src/test_main_lever4.py
@@ -25,17 +25,40 @@ _PRIOR_KEYS = [
 ]
 
 
+# The nine fan-out sub-WDLs the SMP-1463 preflight requires under the versioned S3 prefix.
+_WDL_FILENAMES = [
+    "download-taxonomy.wdl", "download-nt.wdl", "download-nr.wdl",
+    "compress-nt.wdl", "compress-nr.wdl",
+    "index-nt.wdl", "index-nr.wdl", "index-taxonomy.wdl", "assemble.wdl",
+]
+
+
 class FakePaginator:
     def paginate(self, **kw):
         return [{"Contents": [{"Key": k} for k in _PRIOR_KEYS]}]
 
 
+class _ECRExceptions:
+    class ImageNotFoundException(Exception):
+        pass
+
+
 class FakeS3:
+    # Serves both the s3 and ecr clients (fake_boto3.client returns this for either).
+    exceptions = _ECRExceptions
+
     def get_paginator(self, name):
         return FakePaginator()
 
     def put_object(self, **kw):
         captured["put_objects"].append(kw)
+
+    def list_objects_v2(self, Bucket, Prefix, **kw):
+        # SMP-1463 preflight: report all nine sub-WDLs published under the versioned prefix.
+        return {"Contents": [{"Key": Prefix + fn} for fn in _WDL_FILENAMES]}
+
+    def describe_images(self, **kw):
+        return {"imageDetails": [{"imageTags": [kw["imageIds"][0]["imageTag"]]}]}
 
 
 class FakeSFN:


### PR DESCRIPTION
Couples everything the index-generation pipeline pins to `INDEX_GENERATION_WORKFLOW_VERSION` (the terraform SSOT) so the S3 WDL prefix, the ECR image tag, and the execution name cannot drift, and adds a fail-closed preflight so a dangling version (the observed `v2.4.4` that exists in neither S3 nor ECR) is caught before `StartExecution`.

- `start_index_generation_lambda_src/main.py`: `WORKFLOW_NAME` + `wdl_prefix()` + `build_image_id()` are the ONLY builders of the prefix/tag; the run input and the new `preflight_artifacts_exist()` both derive from them. Preflight lists the 9 sub-WDLs under the versioned S3 prefix and checks the ECR tag; raises `RuntimeError` naming the version + missing artifacts otherwise.
- `terraform/index-generation.tf`: scoped read-only grants (`s3:ListBucket` on the workflows bucket, `ecr:DescribeImages` on the index-generation repo) so the preflight can run; updated SSOT comment.
- Tests: extended fakes + a negative (fail-closed) test + happy-path assertion. Both suites pass offline; flake8 clean.

**Output paths unchanged** -- `output_prefix`, `wdl_uri`, `docker_image_id` are byte-identical to before (existing contract tests still pass); no index rebuild is triggered.

**Terraform apply is NOT part of this PR.** The lambda code + IAM must apply **together** (preflight fail-closes if IAM lands without the grants, or vice-versa) -- held for the reviewer-gated targeted-apply channel post-merge, never the bulk Deploy.

Jira: SMP-1463.